### PR TITLE
Add feedback orchestrator skeleton for self-healing support

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -58,6 +58,7 @@ The application is a complex, multi-service, containerized system. Understanding
     -   **Langfuse:** Provides deep observability into the performance and quality of the LLM agent.
     -   **Promtail & Loki:** Aggregate logs from all services, including Traefik's traffic logs.
     -   **Grafana:** The central dashboard for visualizing all monitoring data.
+    -   **Feedback Orchestrator:** Consumes logs, monitoring exports and database signals to deploy specialised agents for self-healing.
 
 ## 3. Key Files & Conventions
 

--- a/DIFF_20250811_015428.md
+++ b/DIFF_20250811_015428.md
@@ -1,0 +1,6 @@
+## Changes on 2025-08-11 01:54:28 UTC
+
+- Added `feedback_orchestrator.py` implementing feedback orchestration stub.
+- Created tests for orchestrator in `test_feedback_orchestrator.py`.
+- Updated documentation to describe self-healing feedback system.
+- Appended instructions about feedback orchestrator to `AGENT_INSTRUCTIONS.md`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository provides a one-click deployment script to set up the entire cont
     -   **Unified Dashboards (Grafana):** A single pane of glass for all metrics, logs, and traces.
     -   **Security Auditing:** A database-level audit log tracks all user actions.
     -   **Traffic Monitoring:** Traefik access logs are captured for security and performance analysis.
+    -   **Self-Healing Feedback:** An AI orchestrator analyses logs, monitoring exports and database state to launch specialised agents for automatic remediation.
 -   **Integrated Tooling:**
     -   **AI Prototyping Lab (Flowise):** A low-code UI for rapidly building and testing new AI flows.
     -   **Workflow Automation (n8n):** An integrated n8n instance for connecting your AI to other services.

--- a/RECOMMENDATIONS_20250811_015428.md
+++ b/RECOMMENDATIONS_20250811_015428.md
@@ -1,0 +1,5 @@
+## Recommendations on 2025-08-11 01:54:28 UTC
+
+- Implement real adapters to ingest data from Loki, Supabase, and pgvector for richer feedback.
+- Introduce persistent storage of remediation actions for auditing.
+- Expose orchestrator controls via API endpoints for transparency.

--- a/src/fastapi_app/feedback_orchestrator.py
+++ b/src/fastapi_app/feedback_orchestrator.py
@@ -40,7 +40,6 @@ class FeedbackOrchestrator:
         other monitoring files available to the application.
         """
         logger.debug("Collecting feedback signals")
-        await asyncio.sleep(0)  # yield control in async contexts
         return {
             "logs": [],
             "metrics": {},

--- a/src/fastapi_app/feedback_orchestrator.py
+++ b/src/fastapi_app/feedback_orchestrator.py
@@ -1,0 +1,70 @@
+"""Feedback orchestration for self-healing web application."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class LLMProvider(Protocol):
+    """Protocol for an LLM provider that can analyse data and deploy agents."""
+
+    async def analyse(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Perform high level analysis of collected telemetry."""
+
+    async def deploy_agents(self, plan: Dict[str, Any]) -> List[str]:
+        """Deploy specialised agents to execute the remediation plan."""
+
+
+@dataclass
+class FeedbackOrchestrator:
+    """Coordinates feedback from multiple observability sources.
+
+    The orchestrator gathers signals from logs, monitoring exports, audit logs,
+    vector stores and SQL databases. It then asks an LLM provider to analyse the
+    combined context and, if necessary, launches specialised agents to address
+    detected issues.
+    """
+
+    provider: LLMProvider
+
+    async def collect_signals(self) -> Dict[str, Any]:
+        """Collect signals from various subsystems.
+
+        This placeholder implementation returns dummy values but in production it
+        would aggregate data from Loki, Supabase, pgvector, the audit log and any
+        other monitoring files available to the application.
+        """
+        logger.debug("Collecting feedback signals")
+        await asyncio.sleep(0)  # yield control in async contexts
+        return {
+            "logs": [],
+            "metrics": {},
+            "audit": [],
+        }
+
+    async def analyse(self, signals: Dict[str, Any]) -> Dict[str, Any]:
+        """Send signals to the LLM provider for analysis."""
+        logger.debug("Analysing signals via provider")
+        return await self.provider.analyse(signals)
+
+    async def dispatch(self, plan: Dict[str, Any]) -> List[str]:
+        """Deploy specialised agents according to the remediation plan."""
+        logger.debug("Dispatching specialised agents")
+        return await self.provider.deploy_agents(plan)
+
+    async def heal(self) -> List[str]:
+        """High level orchestration entry point.
+
+        Collects signals, requests analysis and dispatches remedial agents.
+        Returns identifiers of launched agents for observability purposes.
+        """
+        signals = await self.collect_signals()
+        plan = await self.analyse(signals)
+        actions = await self.dispatch(plan)
+        logger.info("Launched agents: %s", actions)
+        return actions

--- a/src/fastapi_app/tests/test_feedback_orchestrator.py
+++ b/src/fastapi_app/tests/test_feedback_orchestrator.py
@@ -1,0 +1,22 @@
+import pytest
+from typing import Dict, Any, List
+
+from fastapi_app.feedback_orchestrator import FeedbackOrchestrator, LLMProvider
+
+
+class DummyProvider:
+    """Simple provider used for testing."""
+
+    async def analyse(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return {"plan": "ok"}
+
+    async def deploy_agents(self, plan: Dict[str, Any]) -> List[str]:
+        assert plan == {"plan": "ok"}
+        return ["agent-1"]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_heal_flow():
+    orchestrator = FeedbackOrchestrator(provider=DummyProvider())
+    agents = await orchestrator.heal()
+    assert agents == ["agent-1"]


### PR DESCRIPTION
## Summary
- introduce `FeedbackOrchestrator` skeleton that collects signals and dispatches specialised agents
- document self-healing feedback system and update project instructions
- add unit test and timestamped change/recommendation records

## Testing
- `pre-commit run --files AGENT_INSTRUCTIONS.md README.md src/fastapi_app/feedback_orchestrator.py src/fastapi_app/tests/test_feedback_orchestrator.py DIFF_20250811_015428.md RECOMMENDATIONS_20250811_015428.md`
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*
- `pytest src/fastapi_app/tests/test_feedback_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68994c9f3b74832aad627a89a7543af2

## Summary by Sourcery

Add a skeleton FeedbackOrchestrator for self-healing capabilities and wire it into documentation and tests

New Features:
- Introduce FeedbackOrchestrator with asynchronous methods to collect signals, analyse with an LLM provider, and dispatch remediation agents

Enhancements:
- Document the self-healing feedback system in AGENT_INSTRUCTIONS.md and README.md

Tests:
- Add unit test for the orchestrator’s heal flow using a DummyProvider

Chores:
- Include timestamped change and recommendation records for auditing