### PR TITLE
raise runtime error on missing env vars

### DIFF
--- a/DIFF_20250811_020137.md
+++ b/DIFF_20250811_020137.md
@@ -1,0 +1,4 @@
+# Diff - 2025-08-11 02:01:37 UTC
+- replace print with `logger.error` in configuration validation
+- raise `RuntimeError` when required environment variables are missing
+- update tests to expect raised exceptions instead of boolean returns

--- a/RECOMMENDATIONS_20250811_020137.md
+++ b/RECOMMENDATIONS_20250811_020137.md
@@ -1,0 +1,3 @@
+# Recommendations - 2025-08-11 02:01:37 UTC
+- Centralize environment configuration validation to avoid code duplication.
+- Add tests for logging output to ensure proper error reporting.

--- a/src/fastapi_app/providers.py
+++ b/src/fastapi_app/providers.py
@@ -3,11 +3,14 @@ Flexible provider configuration for LLM and embedding models.
 """
 
 import os
+import logging
 from typing import Optional
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.openai import OpenAIModel
 import openai
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables
 load_dotenv()
@@ -16,17 +19,17 @@ load_dotenv()
 def get_llm_model(model_choice: Optional[str] = None) -> OpenAIModel:
     """
     Get LLM model configuration based on environment variables.
-    
+
     Args:
         model_choice: Optional override for model choice
-    
+
     Returns:
         Configured OpenAI-compatible model
     """
-    llm_choice = model_choice or os.getenv('LLM_CHOICE', 'gpt-4-turbo-preview')
-    base_url = os.getenv('LLM_BASE_URL', 'https://api.openai.com/v1')
-    api_key = os.getenv('LLM_API_KEY', 'ollama')
-    
+    llm_choice = model_choice or os.getenv("LLM_CHOICE", "gpt-4-turbo-preview")
+    base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1")
+    api_key = os.getenv("LLM_API_KEY", "ollama")
+
     provider = OpenAIProvider(base_url=base_url, api_key=api_key)
     return OpenAIModel(llm_choice, provider=provider)
 
@@ -34,95 +37,95 @@ def get_llm_model(model_choice: Optional[str] = None) -> OpenAIModel:
 def get_embedding_client() -> openai.AsyncOpenAI:
     """
     Get embedding client configuration based on environment variables.
-    
+
     Returns:
         Configured OpenAI-compatible client for embeddings
     """
-    base_url = os.getenv('EMBEDDING_BASE_URL', 'https://api.openai.com/v1')
-    api_key = os.getenv('EMBEDDING_API_KEY', 'ollama')
-    
-    return openai.AsyncOpenAI(
-        base_url=base_url,
-        api_key=api_key
-    )
+    base_url = os.getenv("EMBEDDING_BASE_URL", "https://api.openai.com/v1")
+    api_key = os.getenv("EMBEDDING_API_KEY", "ollama")
+
+    return openai.AsyncOpenAI(base_url=base_url, api_key=api_key)
 
 
 def get_embedding_model() -> str:
     """
     Get embedding model name from environment.
-    
+
     Returns:
         Embedding model name
     """
-    return os.getenv('EMBEDDING_MODEL', 'text-embedding-3-small')
+    return os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 
 
 def get_ingestion_model() -> OpenAIModel:
     """
     Get ingestion-specific LLM model (can be faster/cheaper than main model).
-    
+
     Returns:
         Configured model for ingestion tasks
     """
-    ingestion_choice = os.getenv('INGESTION_LLM_CHOICE')
-    
+    ingestion_choice = os.getenv("INGESTION_LLM_CHOICE")
+
     # If no specific ingestion model, use the main model
     if not ingestion_choice:
         return get_llm_model()
-    
+
     return get_llm_model(model_choice=ingestion_choice)
 
 
 # Provider information functions
 def get_llm_provider() -> str:
     """Get the LLM provider name."""
-    return os.getenv('LLM_PROVIDER', 'openai')
+    return os.getenv("LLM_PROVIDER", "openai")
 
 
 def get_embedding_provider() -> str:
     """Get the embedding provider name."""
-    return os.getenv('EMBEDDING_PROVIDER', 'openai')
+    return os.getenv("EMBEDDING_PROVIDER", "openai")
 
 
 def validate_configuration() -> bool:
     """
     Validate that required environment variables are set.
-    
+
     Returns:
         True if configuration is valid
+    Raises:
+        RuntimeError: If any required variables are missing
     """
     required_vars = [
-        'LLM_API_KEY',
-        'LLM_CHOICE',
-        'EMBEDDING_API_KEY',
-        'EMBEDDING_MODEL'
+        "LLM_API_KEY",
+        "LLM_CHOICE",
+        "EMBEDDING_API_KEY",
+        "EMBEDDING_MODEL",
     ]
-    
-    missing_vars = []
-    for var in required_vars:
-        if not os.getenv(var):
-            missing_vars.append(var)
-    
+
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+
     if missing_vars:
-        print(f"Missing required environment variables: {', '.join(missing_vars)}")
-        return False
-    
+        logger.error(
+            "Missing required environment variables: %s", ", ".join(missing_vars)
+        )
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing_vars)}"
+        )
+
     return True
 
 
 def get_model_info() -> dict:
     """
     Get information about current model configuration.
-    
+
     Returns:
         Dictionary with model configuration info
     """
     return {
         "llm_provider": get_llm_provider(),
-        "llm_model": os.getenv('LLM_CHOICE'),
-        "llm_base_url": os.getenv('LLM_BASE_URL'),
+        "llm_model": os.getenv("LLM_CHOICE"),
+        "llm_base_url": os.getenv("LLM_BASE_URL"),
         "embedding_provider": get_embedding_provider(),
         "embedding_model": get_embedding_model(),
-        "embedding_base_url": os.getenv('EMBEDDING_BASE_URL'),
-        "ingestion_model": os.getenv('INGESTION_LLM_CHOICE', 'same as main'),
+        "embedding_base_url": os.getenv("EMBEDDING_BASE_URL"),
+        "ingestion_model": os.getenv("INGESTION_LLM_CHOICE", "same as main"),
     }

--- a/src/fastapi_app/tests/test_providers.py
+++ b/src/fastapi_app/tests/test_providers.py
@@ -1,27 +1,53 @@
 import pytest
 import os
 from unittest.mock import patch
-from fastapi_app.providers import get_llm_model, get_embedding_client, get_embedding_model, validate_configuration
+from fastapi_app.providers import (
+    get_llm_model,
+    get_embedding_client,
+    get_embedding_model,
+    validate_configuration,
+)
+
 
 def test_get_llm_model_default():
     """Tests that the default LLM model is configured correctly."""
-    with patch.dict(os.environ, {"LLM_CHOICE": "gpt-test", "LLM_BASE_URL": "http://test.local", "LLM_API_KEY": "test-key"}):
+    with patch.dict(
+        os.environ,
+        {
+            "LLM_CHOICE": "gpt-test",
+            "LLM_BASE_URL": "http://test.local",
+            "LLM_API_KEY": "test-key",
+        },
+    ):
         model = get_llm_model()
         assert model.model_name == "gpt-test"
         assert model.client.base_url == "http://test.local"
 
+
 def test_get_llm_model_override():
     """Tests that the model choice can be overridden."""
-    with patch.dict(os.environ, {"LLM_CHOICE": "gpt-default", "LLM_BASE_URL": "http://test.local", "LLM_API_KEY": "test-key"}):
+    with patch.dict(
+        os.environ,
+        {
+            "LLM_CHOICE": "gpt-default",
+            "LLM_BASE_URL": "http://test.local",
+            "LLM_API_KEY": "test-key",
+        },
+    ):
         model = get_llm_model(model_choice="gpt-override")
         assert model.model_name == "gpt-override"
 
+
 def test_get_embedding_client():
     """Tests that the embedding client is configured correctly from env vars."""
-    with patch.dict(os.environ, {"EMBEDDING_BASE_URL": "http://embed.local", "EMBEDDING_API_KEY": "embed-key"}):
+    with patch.dict(
+        os.environ,
+        {"EMBEDDING_BASE_URL": "http://embed.local", "EMBEDDING_API_KEY": "embed-key"},
+    ):
         client = get_embedding_client()
         assert client.base_url == "http://embed.local"
         assert client.api_key == "embed-key"
+
 
 def test_get_embedding_model():
     """Tests that the embedding model name is retrieved correctly."""
@@ -29,17 +55,23 @@ def test_get_embedding_model():
         model_name = get_embedding_model()
         assert model_name == "embed-test-model"
 
+
 def test_validate_configuration_success():
     """Tests that validation passes when all required env vars are set."""
-    with patch.dict(os.environ, {
-        "LLM_API_KEY": "key1",
-        "LLM_CHOICE": "model1",
-        "EMBEDDING_API_KEY": "key2",
-        "EMBEDDING_MODEL": "model2"
-    }):
+    with patch.dict(
+        os.environ,
+        {
+            "LLM_API_KEY": "key1",
+            "LLM_CHOICE": "model1",
+            "EMBEDDING_API_KEY": "key2",
+            "EMBEDDING_MODEL": "model2",
+        },
+    ):
         assert validate_configuration() is True
+
 
 def test_validate_configuration_failure():
     """Tests that validation fails when env vars are missing."""
     with patch.dict(os.environ, {}, clear=True):
-        assert validate_configuration() is False
+        with pytest.raises(RuntimeError):
+            validate_configuration()


### PR DESCRIPTION
## Summary
- log missing environment variables with `logger.error`
- raise `RuntimeError` when required env vars are absent and update tests to expect exceptions

## Testing
- `pre-commit run --files src/fastapi_app/providers.py src/fastapi_app/tests/test_providers.py`
- `pre-commit run --files DIFF_20250811_020137.md RECOMMENDATIONS_20250811_020137.md`
- `pytest src/fastapi_app/tests/test_providers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68994e185508832ab5c35f61dedc1ab5

## Summary by Sourcery

Enforce strict environment variable validation by logging errors and raising RuntimeError if any required variables are missing, and update tests to expect these exceptions.

Enhancements:
- Add a logger and replace print statements with logger.error in validate_configuration
- Raise RuntimeError in validate_configuration when required env vars are absent instead of returning False

Tests:
- Update test_validate_configuration to expect RuntimeError on missing env vars