### PR TITLE
Handle stream errors and closure

### DIFF
--- a/DIFF_20250811_020450.md
+++ b/DIFF_20250811_020450.md
@@ -1,0 +1,2 @@
+## Changes
+- Wrap `generate_stream` body in `try`/`except`/`finally` to emit SSE errors, close partially started runs, and send a terminating `end` event.

--- a/RECOMMENDATIONS_20250811_020450.md
+++ b/RECOMMENDATIONS_20250811_020450.md
@@ -1,0 +1,2 @@
+## Recommendations
+- Consider adding unit tests for `generate_stream` to validate error handling and end event emission.


### PR DESCRIPTION
## Summary
- Wrap `generate_stream` in a try/except/finally block to emit SSE error events, close partial runs, and send a terminating `end` event.
- Document changes and improvement suggestions.

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*


------
https://chatgpt.com/codex/tasks/task_e_68994e199bdc832aa5e6c2aa3e672470