### PR TITLE
feat: add auth dependency to chat and search

### DIFF
--- a/DIFF_20250811_020626.md
+++ b/DIFF_20250811_020626.md
@@ -1,0 +1,4 @@
+## 2025-08-11 02:06:26 UTC
+- Added `verify_auth_token` helper in `src/fastapi_app/db_utils.py` for simple bearer token validation.
+- Introduced `auth_dependency` using `HTTPBearer` in `src/fastapi_app/api.py` and applied it to `/chat`, `/chat/stream`, and `/search/*` endpoints.
+- Updated tests in `src/fastapi_app/tests/test_api.py` to mock authentication and send bearer tokens.

--- a/RECOMMENDATIONS_20250811_020626.md
+++ b/RECOMMENDATIONS_20250811_020626.md
@@ -1,0 +1,3 @@
+## 2025-08-11 02:06:26 UTC
+- Replace the simple bearer token check with actual Supabase session validation for stronger security.
+- Consolidate environment variable setup so all test suites share a common configuration without importing `tests.conftest` manually.

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import uuid
 
 from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -27,6 +28,7 @@ from fastapi_app.db_utils import (
     add_message,
     get_session_messages,
     test_connection,
+    verify_auth_token,
 )
 from fastapi_app.graph_utils import initialize_graph, close_graph, test_graph_connection
 from fastapi_app.models import (
@@ -101,6 +103,19 @@ logging.basicConfig(
 # Set debug level for our module during development
 if APP_ENV == "development":
     logger.setLevel(logging.DEBUG)
+
+
+security = HTTPBearer()
+
+
+async def auth_dependency(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
+    """Simple bearer token authentication dependency."""
+    token = credentials.credentials
+    if not await verify_auth_token(token):
+        raise HTTPException(status_code=401, detail="Invalid or missing authentication")
+    return token
 
 
 @asynccontextmanager
@@ -427,7 +442,7 @@ async def health_check():
 
 
 @app.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+async def chat(request: ChatRequest, auth: str = Depends(auth_dependency)):
     """Non-streaming chat endpoint."""
     try:
         # Get or create session
@@ -451,7 +466,7 @@ async def chat(request: ChatRequest):
 
 
 @app.post("/chat/stream")
-async def chat_stream(request: ChatRequest):
+async def chat_stream(request: ChatRequest, auth: str = Depends(auth_dependency)):
     """Streaming chat endpoint using Server-Sent Events."""
     try:
         # Get or create session
@@ -561,7 +576,7 @@ async def chat_stream(request: ChatRequest):
 
 
 @app.post("/search/vector")
-async def search_vector(request: SearchRequest):
+async def search_vector(request: SearchRequest, auth: str = Depends(auth_dependency)):
     """Vector search endpoint."""
     try:
         input_data = VectorSearchInput(query=request.query, limit=request.limit)
@@ -585,7 +600,7 @@ async def search_vector(request: SearchRequest):
 
 
 @app.post("/search/graph")
-async def search_graph(request: SearchRequest):
+async def search_graph(request: SearchRequest, auth: str = Depends(auth_dependency)):
     """Knowledge graph search endpoint."""
     try:
         input_data = GraphSearchInput(query=request.query)
@@ -609,7 +624,7 @@ async def search_graph(request: SearchRequest):
 
 
 @app.post("/search/hybrid")
-async def search_hybrid(request: SearchRequest):
+async def search_hybrid(request: SearchRequest, auth: str = Depends(auth_dependency)):
     """Hybrid search endpoint."""
     try:
         input_data = HybridSearchInput(query=request.query, limit=request.limit)

--- a/src/fastapi_app/db_utils.py
+++ b/src/fastapi_app/db_utils.py
@@ -21,22 +21,31 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 
+async def verify_auth_token(token: str) -> bool:
+    """Verify bearer token using environment variable."""
+    expected = os.getenv("API_AUTH_TOKEN")
+    if not expected:
+        logger.warning("API_AUTH_TOKEN not set")
+        return False
+    return token == expected
+
+
 class DatabasePool:
     """Manages PostgreSQL connection pool."""
-    
+
     def __init__(self, database_url: Optional[str] = None):
         """
         Initialize database pool.
-        
+
         Args:
             database_url: PostgreSQL connection URL
         """
         self.database_url = database_url or os.getenv("DATABASE_URL")
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable not set")
-        
+
         self.pool: Optional[Pool] = None
-    
+
     async def initialize(self):
         """Create connection pool."""
         if not self.pool:
@@ -45,23 +54,23 @@ class DatabasePool:
                 min_size=5,
                 max_size=20,
                 max_inactive_connection_lifetime=300,
-                command_timeout=60
+                command_timeout=60,
             )
             logger.info("Database connection pool initialized")
-    
+
     async def close(self):
         """Close connection pool."""
         if self.pool:
             await self.pool.close()
             self.pool = None
             logger.info("Database connection pool closed")
-    
+
     @asynccontextmanager
     async def acquire(self):
         """Acquire a connection from the pool."""
         if not self.pool:
             await self.initialize()
-        
+
         async with self.pool.acquire() as connection:
             yield connection
 
@@ -84,22 +93,22 @@ async def close_database():
 async def create_session(
     user_id: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    timeout_minutes: int = 60
+    timeout_minutes: int = 60,
 ) -> str:
     """
     Create a new session.
-    
+
     Args:
         user_id: Optional user identifier
         metadata: Optional session metadata
         timeout_minutes: Session timeout in minutes
-    
+
     Returns:
         Session ID
     """
     async with db_pool.acquire() as conn:
         expires_at = datetime.now(timezone.utc) + timedelta(minutes=timeout_minutes)
-        
+
         result = await conn.fetchrow(
             """
             INSERT INTO sessions (user_id, metadata, expires_at)
@@ -108,26 +117,26 @@ async def create_session(
             """,
             user_id,
             json.dumps(metadata or {}),
-            expires_at
+            expires_at,
         )
-        
+
         return result["id"]
 
 
 async def get_session(session_id: str) -> Optional[Dict[str, Any]]:
     """
     Get session by ID.
-    
+
     Args:
         session_id: Session UUID
-    
+
     Returns:
         Session data or None if not found/expired
     """
     async with db_pool.acquire() as conn:
         result = await conn.fetchrow(
             """
-            SELECT 
+            SELECT
                 id::text,
                 user_id,
                 metadata,
@@ -138,9 +147,9 @@ async def get_session(session_id: str) -> Optional[Dict[str, Any]]:
             WHERE id = $1::uuid
             AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
             """,
-            session_id
+            session_id,
         )
-        
+
         if result:
             return {
                 "id": result["id"],
@@ -148,20 +157,22 @@ async def get_session(session_id: str) -> Optional[Dict[str, Any]]:
                 "metadata": json.loads(result["metadata"]),
                 "created_at": result["created_at"].isoformat(),
                 "updated_at": result["updated_at"].isoformat(),
-                "expires_at": result["expires_at"].isoformat() if result["expires_at"] else None
+                "expires_at": result["expires_at"].isoformat()
+                if result["expires_at"]
+                else None,
             }
-        
+
         return None
 
 
 async def update_session(session_id: str, metadata: Dict[str, Any]) -> bool:
     """
     Update session metadata.
-    
+
     Args:
         session_id: Session UUID
         metadata: New metadata to merge
-    
+
     Returns:
         True if updated, False if not found
     """
@@ -174,28 +185,25 @@ async def update_session(session_id: str, metadata: Dict[str, Any]) -> bool:
             AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
             """,
             session_id,
-            json.dumps(metadata)
+            json.dumps(metadata),
         )
-        
+
         return result.split()[-1] != "0"
 
 
 # Message Management Functions
 async def add_message(
-    session_id: str,
-    role: str,
-    content: str,
-    metadata: Optional[Dict[str, Any]] = None
+    session_id: str, role: str, content: str, metadata: Optional[Dict[str, Any]] = None
 ) -> str:
     """
     Add a message to a session.
-    
+
     Args:
         session_id: Session UUID
         role: Message role (user/assistant/system)
         content: Message content
         metadata: Optional message metadata
-    
+
     Returns:
         Message ID
     """
@@ -209,29 +217,28 @@ async def add_message(
             session_id,
             role,
             content,
-            json.dumps(metadata or {})
+            json.dumps(metadata or {}),
         )
-        
+
         return result["id"]
 
 
 async def get_session_messages(
-    session_id: str,
-    limit: Optional[int] = None
+    session_id: str, limit: Optional[int] = None
 ) -> List[Dict[str, Any]]:
     """
     Get messages for a session.
-    
+
     Args:
         session_id: Session UUID
         limit: Maximum number of messages to return
-    
+
     Returns:
         List of messages ordered by creation time
     """
     async with db_pool.acquire() as conn:
         query = """
-            SELECT 
+              SELECT
                 id::text,
                 role,
                 content,
@@ -241,19 +248,19 @@ async def get_session_messages(
             WHERE session_id = $1::uuid
             ORDER BY created_at
         """
-        
+
         if limit:
             query += f" LIMIT {limit}"
-        
+
         results = await conn.fetch(query, session_id)
-        
+
         return [
             {
                 "id": row["id"],
                 "role": row["role"],
                 "content": row["content"],
                 "metadata": json.loads(row["metadata"]),
-                "created_at": row["created_at"].isoformat()
+                "created_at": row["created_at"].isoformat(),
             }
             for row in results
         ]
@@ -263,17 +270,17 @@ async def get_session_messages(
 async def get_document(document_id: str) -> Optional[Dict[str, Any]]:
     """
     Get document by ID.
-    
+
     Args:
         document_id: Document UUID
-    
+
     Returns:
         Document data or None if not found
     """
     async with db_pool.acquire() as conn:
         result = await conn.fetchrow(
             """
-            SELECT 
+              SELECT
                 id::text,
                 title,
                 source,
@@ -284,9 +291,9 @@ async def get_document(document_id: str) -> Optional[Dict[str, Any]]:
             FROM documents
             WHERE id = $1::uuid
             """,
-            document_id
+            document_id,
         )
-        
+
         if result:
             return {
                 "id": result["id"],
@@ -295,31 +302,29 @@ async def get_document(document_id: str) -> Optional[Dict[str, Any]]:
                 "content": result["content"],
                 "metadata": json.loads(result["metadata"]),
                 "created_at": result["created_at"].isoformat(),
-                "updated_at": result["updated_at"].isoformat()
+                "updated_at": result["updated_at"].isoformat(),
             }
-        
+
         return None
 
 
 async def list_documents(
-    limit: int = 100,
-    offset: int = 0,
-    metadata_filter: Optional[Dict[str, Any]] = None
+    limit: int = 100, offset: int = 0, metadata_filter: Optional[Dict[str, Any]] = None
 ) -> List[Dict[str, Any]]:
     """
     List documents with optional filtering.
-    
+
     Args:
         limit: Maximum number of documents to return
         offset: Number of documents to skip
         metadata_filter: Optional metadata filter
-    
+
     Returns:
         List of documents
     """
     async with db_pool.acquire() as conn:
         query = """
-            SELECT 
+              SELECT
                 d.id::text,
                 d.title,
                 d.source,
@@ -330,27 +335,30 @@ async def list_documents(
             FROM documents d
             LEFT JOIN chunks c ON d.id = c.document_id
         """
-        
+
         params = []
         conditions = []
-        
+
         if metadata_filter:
             conditions.append(f"d.metadata @> ${len(params) + 1}::jsonb")
             params.append(json.dumps(metadata_filter))
-        
+
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
-        
+
         query += """
             GROUP BY d.id, d.title, d.source, d.metadata, d.created_at, d.updated_at
             ORDER BY d.created_at DESC
             LIMIT $%d OFFSET $%d
-        """ % (len(params) + 1, len(params) + 2)
-        
+        """ % (
+            len(params) + 1,
+            len(params) + 2,
+        )
+
         params.extend([limit, offset])
-        
+
         results = await conn.fetch(query, *params)
-        
+
         return [
             {
                 "id": row["id"],
@@ -359,7 +367,7 @@ async def list_documents(
                 "metadata": json.loads(row["metadata"]),
                 "created_at": row["created_at"].isoformat(),
                 "updated_at": row["updated_at"].isoformat(),
-                "chunk_count": row["chunk_count"]
+                "chunk_count": row["chunk_count"],
             }
             for row in results
         ]
@@ -367,30 +375,27 @@ async def list_documents(
 
 # Vector Search Functions
 async def vector_search(
-    embedding: List[float],
-    limit: int = 10
+    embedding: List[float], limit: int = 10
 ) -> List[Dict[str, Any]]:
     """
     Perform vector similarity search.
-    
+
     Args:
         embedding: Query embedding vector
         limit: Maximum number of results
-    
+
     Returns:
         List of matching chunks ordered by similarity (best first)
     """
     async with db_pool.acquire() as conn:
         # Convert embedding to PostgreSQL vector string format
         # PostgreSQL vector format: '[1.0,2.0,3.0]' (no spaces after commas)
-        embedding_str = '[' + ','.join(map(str, embedding)) + ']'
-        
+        embedding_str = "[" + ",".join(map(str, embedding)) + "]"
+
         results = await conn.fetch(
-            "SELECT * FROM match_chunks($1::vector, $2)",
-            embedding_str,
-            limit
+            "SELECT * FROM match_chunks($1::vector, $2)", embedding_str, limit
         )
-        
+
         return [
             {
                 "chunk_id": row["chunk_id"],
@@ -399,43 +404,40 @@ async def vector_search(
                 "similarity": row["similarity"],
                 "metadata": json.loads(row["metadata"]),
                 "document_title": row["document_title"],
-                "document_source": row["document_source"]
+                "document_source": row["document_source"],
             }
             for row in results
         ]
 
 
 async def hybrid_search(
-    embedding: List[float],
-    query_text: str,
-    limit: int = 10,
-    text_weight: float = 0.3
+    embedding: List[float], query_text: str, limit: int = 10, text_weight: float = 0.3
 ) -> List[Dict[str, Any]]:
     """
     Perform hybrid search (vector + keyword).
-    
+
     Args:
         embedding: Query embedding vector
         query_text: Query text for keyword search
         limit: Maximum number of results
         text_weight: Weight for text similarity (0-1)
-    
+
     Returns:
         List of matching chunks ordered by combined score (best first)
     """
     async with db_pool.acquire() as conn:
         # Convert embedding to PostgreSQL vector string format
         # PostgreSQL vector format: '[1.0,2.0,3.0]' (no spaces after commas)
-        embedding_str = '[' + ','.join(map(str, embedding)) + ']'
-        
+        embedding_str = "[" + ",".join(map(str, embedding)) + "]"
+
         results = await conn.fetch(
             "SELECT * FROM hybrid_search($1::vector, $2, $3, $4)",
             embedding_str,
             query_text,
             limit,
-            text_weight
+            text_weight,
         )
-        
+
         return [
             {
                 "chunk_id": row["chunk_id"],
@@ -446,7 +448,7 @@ async def hybrid_search(
                 "text_similarity": row["text_similarity"],
                 "metadata": json.loads(row["metadata"]),
                 "document_title": row["document_title"],
-                "document_source": row["document_source"]
+                "document_source": row["document_source"],
             }
             for row in results
         ]
@@ -456,25 +458,24 @@ async def hybrid_search(
 async def get_document_chunks(document_id: str) -> List[Dict[str, Any]]:
     """
     Get all chunks for a document.
-    
+
     Args:
         document_id: Document UUID
-    
+
     Returns:
         List of chunks ordered by chunk index
     """
     async with db_pool.acquire() as conn:
         results = await conn.fetch(
-            "SELECT * FROM get_document_chunks($1::uuid)",
-            document_id
+            "SELECT * FROM get_document_chunks($1::uuid)", document_id
         )
-        
+
         return [
             {
                 "chunk_id": row["chunk_id"],
                 "content": row["content"],
                 "chunk_index": row["chunk_index"],
-                "metadata": json.loads(row["metadata"])
+                "metadata": json.loads(row["metadata"]),
             }
             for row in results
         ]
@@ -484,11 +485,11 @@ async def get_document_chunks(document_id: str) -> List[Dict[str, Any]]:
 async def execute_query(query: str, *params) -> List[Dict[str, Any]]:
     """
     Execute a custom query.
-    
+
     Args:
         query: SQL query
         *params: Query parameters
-    
+
     Returns:
         Query results
     """
@@ -500,7 +501,7 @@ async def execute_query(query: str, *params) -> List[Dict[str, Any]]:
 async def test_connection() -> bool:
     """
     Test database connection.
-    
+
     Returns:
         True if connection successful
     """

--- a/src/fastapi_app/tests/test_api.py
+++ b/src/fastapi_app/tests/test_api.py
@@ -1,7 +1,10 @@
+import os
+import tests.conftest  # noqa: F401
+
+import json
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch, AsyncMock, MagicMock
-import json
 from fastapi_app.api import app
 from fastapi_app.models import ChunkResult, GraphSearchResult
 
@@ -12,51 +15,112 @@ client = TestClient(app)
 
 # --- Mocks and Fixtures ---
 
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Mock authentication dependency to always succeed."""
+    with patch(
+        "fastapi_app.api.verify_auth_token", new_callable=AsyncMock, return_value=True
+    ):
+        yield
+
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": "Bearer testtoken"}
+
+
 @pytest.fixture
 def mock_db_utils():
     """Mocks all functions in the db_utils module."""
-    with patch('fastapi_app.api.initialize_database', new_callable=AsyncMock) as mock_init_db, \
-         patch('fastapi_app.api.close_database', new_callable=AsyncMock) as mock_close_db, \
-         patch('fastapi_app.api.create_session', new_callable=AsyncMock, return_value="new-session-123") as mock_create, \
-         patch('fastapi_app.api.get_session', new_callable=AsyncMock, return_value={"id": "existing-session-456"}) as mock_get, \
-         patch('fastapi_app.api.add_message', new_callable=AsyncMock) as mock_add, \
-         patch('fastapi_app.api.get_session_messages', new_callable=AsyncMock, return_value=[]) as mock_get_messages, \
-         patch('fastapi_app.api.test_connection', new_callable=AsyncMock, return_value=True) as mock_test_conn:
+    with patch(
+        "fastapi_app.api.initialize_database", new_callable=AsyncMock
+    ) as _, patch("fastapi_app.api.close_database", new_callable=AsyncMock) as _, patch(
+        "fastapi_app.api.create_session",
+        new_callable=AsyncMock,
+        return_value="new-session-123",
+    ) as mock_create, patch(
+        "fastapi_app.api.get_session",
+        new_callable=AsyncMock,
+        return_value={"id": "existing-session-456"},
+    ) as mock_get, patch(
+        "fastapi_app.api.add_message", new_callable=AsyncMock
+    ) as mock_add, patch(
+        "fastapi_app.api.get_session_messages", new_callable=AsyncMock, return_value=[]
+    ) as mock_get_messages, patch(
+        "fastapi_app.api.test_connection", new_callable=AsyncMock, return_value=True
+    ) as _:
         yield {
             "create_session": mock_create,
             "get_session": mock_get,
             "add_message": mock_add,
-            "get_session_messages": mock_get_messages
+            "get_session_messages": mock_get_messages,
         }
+
 
 @pytest.fixture
 def mock_graph_utils():
     """Mocks all functions in the graph_utils module."""
-    with patch('fastapi_app.api.initialize_graph', new_callable=AsyncMock) as mock_init_graph, \
-         patch('fastapi_app.api.close_graph', new_callable=AsyncMock) as mock_close_graph, \
-         patch('fastapi_app.api.test_graph_connection', new_callable=AsyncMock, return_value=True) as mock_test_graph:
+    with patch("fastapi_app.api.initialize_graph", new_callable=AsyncMock) as _, patch(
+        "fastapi_app.api.close_graph", new_callable=AsyncMock
+    ) as _, patch(
+        "fastapi_app.api.test_graph_connection",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as _:
         yield
+
 
 @pytest.fixture
 def mock_agent_execution():
     """Mocks the core agent execution logic."""
-    with patch('fastapi_app.api.execute_agent', new_callable=AsyncMock) as mock_execute:
-        mock_execute.return_value = ("Mocked AI response", [{"tool_name": "vector_search", "args": {"query": "Hello"}}])
+    with patch("fastapi_app.api.execute_agent", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = (
+            "Mocked AI response",
+            [{"tool_name": "vector_search", "args": {"query": "Hello"}}],
+        )
         yield mock_execute
+
 
 @pytest.fixture
 def mock_tools():
     """Mocks the individual search tools."""
-    with patch('fastapi_app.api.vector_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="vector search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_vector, \
-         patch('fastapi_app.api.graph_search_tool', new_callable=AsyncMock, return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")]) as mock_graph, \
-         patch('fastapi_app.api.hybrid_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="hybrid search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_hybrid:
-        yield {
-            "vector": mock_vector,
-            "graph": mock_graph,
-            "hybrid": mock_hybrid
-        }
+    with patch(
+        "fastapi_app.api.vector_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="vector search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_vector, patch(
+        "fastapi_app.api.graph_search_tool",
+        new_callable=AsyncMock,
+        return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")],
+    ) as mock_graph, patch(
+        "fastapi_app.api.hybrid_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="hybrid search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_hybrid:
+        yield {"vector": mock_vector, "graph": mock_graph, "hybrid": mock_hybrid}
+
 
 # --- API Tests ---
+
 
 async def test_health_check(mock_db_utils, mock_graph_utils):
     response = client.get("/health")
@@ -66,16 +130,26 @@ async def test_health_check(mock_db_utils, mock_graph_utils):
     assert json_data["database"] is True
     assert json_data["graph_database"] is True
 
-async def test_chat_endpoint_creates_session(mock_db_utils, mock_agent_execution):
-    mock_db_utils["get_session"].return_value = None # Simulate no existing session
-    response = client.post("/chat", json={"message": "Hello"})
+
+async def test_chat_endpoint_creates_session(
+    mock_db_utils, mock_agent_execution, auth_headers
+):
+    mock_db_utils["get_session"].return_value = None  # Simulate no existing session
+    response = client.post("/chat", headers=auth_headers, json={"message": "Hello"})
     assert response.status_code == 200
     mock_db_utils["create_session"].assert_called_once()
     mock_agent_execution.assert_called_once()
     assert response.json()["session_id"] == "new-session-123"
 
-async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_execution):
-    response = client.post("/chat", json={"message": "Hello again", "session_id": "existing-session-456"})
+
+async def test_chat_endpoint_uses_existing_session(
+    mock_db_utils, mock_agent_execution, auth_headers
+):
+    response = client.post(
+        "/chat",
+        headers=auth_headers,
+        json={"message": "Hello again", "session_id": "existing-session-456"},
+    )
     assert response.status_code == 200
     mock_db_utils["get_session"].assert_called_with("existing-session-456")
     mock_db_utils["create_session"].assert_not_called()
@@ -83,27 +157,38 @@ async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_exe
     assert response.json()["session_id"] == "existing-session-456"
     assert response.json()["tools_used"][0]["tool_name"] == "vector_search"
 
-async def test_chat_stream_endpoint(mock_db_utils):
+
+async def test_chat_stream_endpoint(mock_db_utils, auth_headers):
     # Mock the agent's streaming logic
-    with patch('fastapi_app.api.rag_agent.iter') as mock_iter:
+    with patch("fastapi_app.api.rag_agent.iter") as mock_iter:
+
         async def mock_streamer(*args, **kwargs):
             yield f"data: {json.dumps({'type': 'session', 'session_id': 'stream-session-789'})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'Hello '})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'World!'})}\n\n"
             yield f"data: {json.dumps({'type': 'tools', 'tools': [{'tool_name': 'test_tool'}]})}\n\n"
             yield f"data: {json.dumps({'type': 'end'})}\n\n"
-        
-        mock_iter.return_value.__aenter__.return_value = mock_streamer() # type: ignore
-        
-        response = client.post("/chat/stream", json={"message": "stream test"})
+
+        mock_iter.return_value.__aenter__.return_value = mock_streamer()  # type: ignore
+
+        response = client.post(
+            "/chat/stream", headers=auth_headers, json={"message": "stream test"}
+        )
         assert response.status_code == 200
         # In a real test client, you would iterate over the streaming response
         # Here we just confirm the endpoint is reachable and returns a streaming content type
         assert "text/event-stream" in response.headers["content-type"]
 
-async def test_vector_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
-        response = client.post("/search/vector", json={"query": "test"})
+
+async def test_vector_search_endpoint(mock_tools, auth_headers):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
+        response = client.post(
+            "/search/vector", headers=auth_headers, json={"query": "test"}
+        )
         assert response.status_code == 200
         json_data = response.json()
         assert json_data["search_type"] == "vector"
@@ -111,8 +196,11 @@ async def test_vector_search_endpoint(mock_tools):
         assert json_data["results"][0]["content"] == "vector search result"
         mock_tools["vector"].assert_called_once()
 
-async def test_graph_search_endpoint(mock_tools):
-    response = client.post("/search/graph", json={"query": "test"})
+
+async def test_graph_search_endpoint(mock_tools, auth_headers):
+    response = client.post(
+        "/search/graph", headers=auth_headers, json={"query": "test"}
+    )
     assert response.status_code == 200
     json_data = response.json()
     assert json_data["search_type"] == "graph"
@@ -120,9 +208,16 @@ async def test_graph_search_endpoint(mock_tools):
     assert json_data["graph_results"][0]["fact"] == "graph search result"
     mock_tools["graph"].assert_called_once()
 
-async def test_hybrid_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
-        response = client.post("/search/hybrid", json={"query": "test"})
+
+async def test_hybrid_search_endpoint(mock_tools, auth_headers):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
+        response = client.post(
+            "/search/hybrid", headers=auth_headers, json={"query": "test"}
+        )
         assert response.status_code == 200
         json_data = response.json()
         assert json_data["search_type"] == "hybrid"


### PR DESCRIPTION
## Summary
- add simple bearer-token auth check
- require auth on chat, chat/stream, and search endpoints
- adjust tests to include authenticated requests

## Testing
- `pre-commit run --files src/fastapi_app/api.py src/fastapi_app/db_utils.py src/fastapi_app/tests/test_api.py`
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*
- `pytest src/fastapi_app/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68994e1a8128832abae9926bf18b2692