### PR TITLE
Add SlowAPI rate limiting to FastAPI app

### DIFF
--- a/DIFF_20250811_020708.md
+++ b/DIFF_20250811_020708.md
@@ -1,0 +1,12 @@
+# Diff log - 20250811_020708
+- Added slowapi dependency to src/fastapi_app/requirements.txt
+- Integrated slowapi rate limiting in src/fastapi_app/api.py (imports, limiter setup, exception handler, chat endpoints)
+- Added rate limit test in src/fastapi_app/tests/test_api.py
+- Documented rate limiting in README.md (feature bullet and configuration section)
+- Created DIFF_20250811_020708.md and RECOMMENDATIONS_20250811_020708.md
+- Added recommendations regarding rate limit configurability and authentication in RECOMMENDATIONS_20250811_020708.md
+- Adjusted mock variable names in src/fastapi_app/tests/test_api.py to satisfy flake8
+- Set DATABASE_URL default in src/fastapi_app/tests/test_api.py to allow test imports
+- Set NEO4J_PASSWORD default in src/fastapi_app/tests/test_api.py for test imports
+- Set LLM_API_KEY default in src/fastapi_app/tests/test_api.py for test imports
+- Set EMBEDDING_API_KEY default in src/fastapi_app/tests/test_api.py for test imports

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository provides a one-click deployment script to set up the entire cont
 -   **Advanced AI Backend:**
     -   **Agentic Framework:** A custom Python backend using Pydantic AI that can reason and use tools.
     -   **Hybrid RAG:** Combines semantic vector search (via Supabase/pgvector) with a temporal **Knowledge Graph** (via Neo4j) for deep, contextual analysis.
-    -   **Secure API:** A robust FastAPI backend with endpoints for ingestion, streaming chat, and model management.
+    -   **Secure API:** A robust FastAPI backend with endpoints for ingestion, streaming chat, model management, and built-in rate limiting.
 -   **Polished User Interface:**
     -   **ChatGPT-like Experience:** A Next.js frontend with a full chat interface, conversation history, and Markdown/code rendering.
     -   **Supabase Auth:** Secure user authentication (login, signup, etc.) managed by Supabase.
@@ -106,3 +106,19 @@ Your application is now fully deployed and operational!
 -   **LLM Observability (Langfuse):** `https://langfuse.your-domain.com`
 -   **Observability (Jaeger):** `https://jaeger.your-domain.com`
 -   **Traefik Dashboard:** `https://traefik.your-domain.com`
+
+### API Rate Limiting
+
+The FastAPI backend uses the `slowapi` library to enforce rate limits.
+
+- **Default limit:** 100 requests per minute per user or IP.
+- **Chat endpoints:** restricted to 5 requests per minute.
+- The limiter uses the `X-User-ID` header when present, otherwise the client's IP address.
+
+Exceeding a limit returns an HTTP 429 response with a JSON body:
+
+```json
+{"error": "Rate limit exceeded", "error_type": "RateLimitExceeded"}
+```
+
+Limits can be adjusted in `src/fastapi_app/api.py`.

--- a/RECOMMENDATIONS_20250811_020708.md
+++ b/RECOMMENDATIONS_20250811_020708.md
@@ -1,0 +1,3 @@
+# Recommendations log - 20250811_020708
+- Consider making rate limits configurable via environment variables.
+- Implement proper user authentication to derive rate-limit keys from authenticated users rather than headers.

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import uuid
 
 from fastapi import FastAPI, HTTPException, Request, Depends
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 import uvicorn
@@ -50,6 +50,11 @@ from fastapi_app.tools import (
     DocumentListInput,
 )
 
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+
 # --- OpenTelemetry Instrumentation ---
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -84,6 +89,14 @@ langfuse = Langfuse()
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+
+def rate_limit_key(request: Request) -> str:
+    """Determine rate limit key based on user ID or IP address."""
+    return request.headers.get("X-User-ID") or get_remote_address(request)
+
+
+limiter = Limiter(key_func=rate_limit_key, default_limits=["100/minute"])
 
 
 # Application configuration
@@ -154,6 +167,10 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Attach rate limiter
+app.state.limiter = limiter
+app.add_middleware(SlowAPIMiddleware)
+
 # Instrument FastAPI app after creation
 FastAPIInstrumentor.instrument_app(app)
 
@@ -167,6 +184,20 @@ app.add_middleware(
 )
 
 app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+
+@app.exception_handler(RateLimitExceeded)
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
+    """Custom response when rate limit is exceeded."""
+    logger.warning(f"Rate limit exceeded: {rate_limit_key(request)}")
+    return JSONResponse(
+        status_code=429,
+        content={
+            "error": "Rate limit exceeded",
+            "error_type": "RateLimitExceeded",
+            "request_id": str(uuid.uuid4()),
+        },
+    )
 
 
 # Helper functions for agent execution
@@ -427,22 +458,25 @@ async def health_check():
 
 
 @app.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+@limiter.limit("5/minute")
+async def chat(request: Request, chat_request: ChatRequest):
     """Non-streaming chat endpoint."""
     try:
         # Get or create session
-        session_id = await get_or_create_session(request)
+        session_id = await get_or_create_session(chat_request)
 
         # Execute agent
         response, tools_used = await execute_agent(
-            message=request.message, session_id=session_id, user_id=request.user_id
+            message=chat_request.message,
+            session_id=session_id,
+            user_id=chat_request.user_id,
         )
 
         return ChatResponse(
             message=response,
             session_id=session_id,
             tools_used=tools_used,
-            metadata={"search_type": str(request.search_type)},
+            metadata={"search_type": str(chat_request.search_type)},
         )
 
     except Exception as e:
@@ -451,11 +485,12 @@ async def chat(request: ChatRequest):
 
 
 @app.post("/chat/stream")
-async def chat_stream(request: ChatRequest):
+@limiter.limit("5/minute")
+async def chat_stream(request: Request, chat_request: ChatRequest):
     """Streaming chat endpoint using Server-Sent Events."""
     try:
         # Get or create session
-        session_id = await get_or_create_session(request)
+        session_id = await get_or_create_session(chat_request)
 
         async def generate_stream() -> AsyncGenerator[str, None]:
             """Generate streaming response using agent.iter() pattern."""
@@ -463,25 +498,27 @@ async def chat_stream(request: ChatRequest):
                 yield f"data: {json.dumps({'type': 'session', 'session_id': session_id})}\n\n"
 
                 # Create dependencies
-                deps = AgentDependencies(session_id=session_id, user_id=request.user_id)
+                deps = AgentDependencies(
+                    session_id=session_id, user_id=chat_request.user_id
+                )
 
                 # Get conversation context
                 context = await get_conversation_context(session_id)
 
                 # Build input with context
-                full_prompt = request.message
+                full_prompt = chat_request.message
                 if context:
                     context_str = "\n".join(
                         [f"{msg['role']}: {msg['content']}" for msg in context[-6:]]
                     )
-                    full_prompt = f"Previous conversation:\n{context_str}\n\nCurrent question: {request.message}"
+                    full_prompt = f"Previous conversation:\n{context_str}\n\nCurrent question: {chat_request.message}"
 
                 # Save user message immediately
                 await add_message(
                     session_id=session_id,
                     role="user",
-                    content=request.message,
-                    metadata={"user_id": request.user_id},
+                    content=chat_request.message,
+                    metadata={"user_id": chat_request.user_id},
                 )
 
                 full_response = ""

--- a/src/fastapi_app/requirements.txt
+++ b/src/fastapi_app/requirements.txt
@@ -14,6 +14,7 @@ pydantic-ai
 openai
 asyncpg
 graphiti-core
+slowapi
 
 # --- Observability ---
 opentelemetry-api

--- a/src/fastapi_app/tests/test_api.py
+++ b/src/fastapi_app/tests/test_api.py
@@ -1,7 +1,14 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch, AsyncMock, MagicMock
 import json
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/db")
+os.environ.setdefault("NEO4J_PASSWORD", "test")
+os.environ.setdefault("LLM_API_KEY", "test")
+os.environ.setdefault("EMBEDDING_API_KEY", "test")
+
 from fastapi_app.api import app
 from fastapi_app.models import ChunkResult, GraphSearchResult
 
@@ -12,51 +19,98 @@ client = TestClient(app)
 
 # --- Mocks and Fixtures ---
 
+
 @pytest.fixture
 def mock_db_utils():
     """Mocks all functions in the db_utils module."""
-    with patch('fastapi_app.api.initialize_database', new_callable=AsyncMock) as mock_init_db, \
-         patch('fastapi_app.api.close_database', new_callable=AsyncMock) as mock_close_db, \
-         patch('fastapi_app.api.create_session', new_callable=AsyncMock, return_value="new-session-123") as mock_create, \
-         patch('fastapi_app.api.get_session', new_callable=AsyncMock, return_value={"id": "existing-session-456"}) as mock_get, \
-         patch('fastapi_app.api.add_message', new_callable=AsyncMock) as mock_add, \
-         patch('fastapi_app.api.get_session_messages', new_callable=AsyncMock, return_value=[]) as mock_get_messages, \
-         patch('fastapi_app.api.test_connection', new_callable=AsyncMock, return_value=True) as mock_test_conn:
+    with patch(
+        "fastapi_app.api.initialize_database", new_callable=AsyncMock
+    ) as _, patch("fastapi_app.api.close_database", new_callable=AsyncMock) as _, patch(
+        "fastapi_app.api.create_session",
+        new_callable=AsyncMock,
+        return_value="new-session-123",
+    ) as mock_create, patch(
+        "fastapi_app.api.get_session",
+        new_callable=AsyncMock,
+        return_value={"id": "existing-session-456"},
+    ) as mock_get, patch(
+        "fastapi_app.api.add_message", new_callable=AsyncMock
+    ) as mock_add, patch(
+        "fastapi_app.api.get_session_messages", new_callable=AsyncMock, return_value=[]
+    ) as mock_get_messages, patch(
+        "fastapi_app.api.test_connection", new_callable=AsyncMock, return_value=True
+    ) as _:
         yield {
             "create_session": mock_create,
             "get_session": mock_get,
             "add_message": mock_add,
-            "get_session_messages": mock_get_messages
+            "get_session_messages": mock_get_messages,
         }
+
 
 @pytest.fixture
 def mock_graph_utils():
     """Mocks all functions in the graph_utils module."""
-    with patch('fastapi_app.api.initialize_graph', new_callable=AsyncMock) as mock_init_graph, \
-         patch('fastapi_app.api.close_graph', new_callable=AsyncMock) as mock_close_graph, \
-         patch('fastapi_app.api.test_graph_connection', new_callable=AsyncMock, return_value=True) as mock_test_graph:
+    with patch("fastapi_app.api.initialize_graph", new_callable=AsyncMock) as _, patch(
+        "fastapi_app.api.close_graph", new_callable=AsyncMock
+    ) as _, patch(
+        "fastapi_app.api.test_graph_connection",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as _:
         yield
+
 
 @pytest.fixture
 def mock_agent_execution():
     """Mocks the core agent execution logic."""
-    with patch('fastapi_app.api.execute_agent', new_callable=AsyncMock) as mock_execute:
-        mock_execute.return_value = ("Mocked AI response", [{"tool_name": "vector_search", "args": {"query": "Hello"}}])
+    with patch("fastapi_app.api.execute_agent", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = (
+            "Mocked AI response",
+            [{"tool_name": "vector_search", "args": {"query": "Hello"}}],
+        )
         yield mock_execute
+
 
 @pytest.fixture
 def mock_tools():
     """Mocks the individual search tools."""
-    with patch('fastapi_app.api.vector_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="vector search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_vector, \
-         patch('fastapi_app.api.graph_search_tool', new_callable=AsyncMock, return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")]) as mock_graph, \
-         patch('fastapi_app.api.hybrid_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="hybrid search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_hybrid:
-        yield {
-            "vector": mock_vector,
-            "graph": mock_graph,
-            "hybrid": mock_hybrid
-        }
+    with patch(
+        "fastapi_app.api.vector_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="vector search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_vector, patch(
+        "fastapi_app.api.graph_search_tool",
+        new_callable=AsyncMock,
+        return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")],
+    ) as mock_graph, patch(
+        "fastapi_app.api.hybrid_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="hybrid search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_hybrid:
+        yield {"vector": mock_vector, "graph": mock_graph, "hybrid": mock_hybrid}
+
 
 # --- API Tests ---
+
 
 async def test_health_check(mock_db_utils, mock_graph_utils):
     response = client.get("/health")
@@ -66,16 +120,20 @@ async def test_health_check(mock_db_utils, mock_graph_utils):
     assert json_data["database"] is True
     assert json_data["graph_database"] is True
 
+
 async def test_chat_endpoint_creates_session(mock_db_utils, mock_agent_execution):
-    mock_db_utils["get_session"].return_value = None # Simulate no existing session
+    mock_db_utils["get_session"].return_value = None  # Simulate no existing session
     response = client.post("/chat", json={"message": "Hello"})
     assert response.status_code == 200
     mock_db_utils["create_session"].assert_called_once()
     mock_agent_execution.assert_called_once()
     assert response.json()["session_id"] == "new-session-123"
 
+
 async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_execution):
-    response = client.post("/chat", json={"message": "Hello again", "session_id": "existing-session-456"})
+    response = client.post(
+        "/chat", json={"message": "Hello again", "session_id": "existing-session-456"}
+    )
     assert response.status_code == 200
     mock_db_utils["get_session"].assert_called_with("existing-session-456")
     mock_db_utils["create_session"].assert_not_called()
@@ -83,26 +141,33 @@ async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_exe
     assert response.json()["session_id"] == "existing-session-456"
     assert response.json()["tools_used"][0]["tool_name"] == "vector_search"
 
+
 async def test_chat_stream_endpoint(mock_db_utils):
     # Mock the agent's streaming logic
-    with patch('fastapi_app.api.rag_agent.iter') as mock_iter:
+    with patch("fastapi_app.api.rag_agent.iter") as mock_iter:
+
         async def mock_streamer(*args, **kwargs):
             yield f"data: {json.dumps({'type': 'session', 'session_id': 'stream-session-789'})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'Hello '})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'World!'})}\n\n"
             yield f"data: {json.dumps({'type': 'tools', 'tools': [{'tool_name': 'test_tool'}]})}\n\n"
             yield f"data: {json.dumps({'type': 'end'})}\n\n"
-        
-        mock_iter.return_value.__aenter__.return_value = mock_streamer() # type: ignore
-        
+
+        mock_iter.return_value.__aenter__.return_value = mock_streamer()  # type: ignore
+
         response = client.post("/chat/stream", json={"message": "stream test"})
         assert response.status_code == 200
         # In a real test client, you would iterate over the streaming response
         # Here we just confirm the endpoint is reachable and returns a streaming content type
         assert "text/event-stream" in response.headers["content-type"]
 
+
 async def test_vector_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
         response = client.post("/search/vector", json={"query": "test"})
         assert response.status_code == 200
         json_data = response.json()
@@ -110,6 +175,7 @@ async def test_vector_search_endpoint(mock_tools):
         assert len(json_data["results"]) == 1
         assert json_data["results"][0]["content"] == "vector search result"
         mock_tools["vector"].assert_called_once()
+
 
 async def test_graph_search_endpoint(mock_tools):
     response = client.post("/search/graph", json={"query": "test"})
@@ -120,8 +186,13 @@ async def test_graph_search_endpoint(mock_tools):
     assert json_data["graph_results"][0]["fact"] == "graph search result"
     mock_tools["graph"].assert_called_once()
 
+
 async def test_hybrid_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
         response = client.post("/search/hybrid", json={"query": "test"})
         assert response.status_code == 200
         json_data = response.json()
@@ -129,3 +200,13 @@ async def test_hybrid_search_endpoint(mock_tools):
         assert len(json_data["results"]) == 1
         assert json_data["results"][0]["content"] == "hybrid search result"
         mock_tools["hybrid"].assert_called_once()
+
+
+async def test_rate_limit_exceeded(mock_db_utils, mock_agent_execution):
+    """Ensure chat endpoint enforces rate limits."""
+    response = None
+    for _ in range(6):
+        response = client.post("/chat", json={"message": "Hello"})
+    assert response is not None
+    assert response.status_code == 429
+    assert response.json()["error_type"] == "RateLimitExceeded"

--- a/src/fastapi_app/tests/test_api.py
+++ b/src/fastapi_app/tests/test_api.py
@@ -189,6 +189,5 @@ async def test_rate_limit_exceeded(mock_db_utils, mock_agent_execution):
     response = None
     for _ in range(6):
         response = client.post("/chat", json={"message": "Hello"})
-    assert response is not None
     assert response.status_code == 429
     assert response.json()["error_type"] == "RateLimitExceeded"


### PR DESCRIPTION
## Summary
- integrate SlowAPI-based rate limiting keyed by user ID or IP with custom 429 errors
- document default and chat-specific limits in README
- cover rate limiting with tests

## Testing
- `python -m pre_commit run --files src/fastapi_app/requirements.txt src/fastapi_app/api.py src/fastapi_app/tests/test_api.py README.md DIFF_20250811_020708.md RECOMMENDATIONS_20250811_020708.md`
- `pytest src/fastapi_app/tests/test_api.py`
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*

------
https://chatgpt.com/codex/tasks/task_e_68994f835fd8832aa0db6e9543e2635e

## Summary by Sourcery

Integrate SlowAPI rate limiting into the FastAPI application with default and chat-specific limits, custom 429 error handling, updated documentation, and tests to verify enforcement.

New Features:
- Enforce rate limits using slowapi with default 100 requests/min per user or IP and 5 requests/min on chat endpoints
- Use X-User-ID header or client IP as the rate limit key
- Return custom HTTP 429 JSON responses when limits are exceeded

Build:
- Add slowapi dependency to requirements

Documentation:
- Update README to document default and chat-specific rate limits and responses

Tests:
- Add test case to verify rate limit enforcement on the chat endpoint
- Refactor existing API tests for consistent mock formatting and flake8 compliance

Chores:
- Include diff log and recommendations files for rate limit configurability and authentication