### PR TITLE
feat: add request and response models

### DIFF
--- a/DIFF_20250811_020809.md
+++ b/DIFF_20250811_020809.md
@@ -1,0 +1,4 @@
+### Changes on 2025-08-11 02:08:09
+- Added `DocumentListRequest` and `DocumentListResponse` models for document listing.
+- Updated API to use these models, added response models to search and session endpoints.
+- Enhanced tests with environment setup and new cases for documents and sessions.

--- a/RECOMMENDATIONS_20250811_020809.md
+++ b/RECOMMENDATIONS_20250811_020809.md
@@ -1,0 +1,3 @@
+### Recommendations on 2025-08-11 02:08:09
+- Centralize test environment variable configuration to avoid repeated setup.
+- Consider adding models for streaming responses for stricter typing.

--- a/src/fastapi_app/models.py
+++ b/src/fastapi_app/models.py
@@ -11,6 +11,7 @@ from enum import Enum
 
 class MessageRole(str, Enum):
     """Message role enumeration."""
+
     USER = "user"
     ASSISTANT = "assistant"
     SYSTEM = "system"
@@ -18,6 +19,7 @@ class MessageRole(str, Enum):
 
 class SearchType(str, Enum):
     """Search type enumeration."""
+
     VECTOR = "vector"
     HYBRID = "hybrid"
     GRAPH = "graph"
@@ -26,28 +28,48 @@ class SearchType(str, Enum):
 # Request Models
 class ChatRequest(BaseModel):
     """Chat request model."""
+
     message: str = Field(..., description="User message")
-    session_id: Optional[str] = Field(None, description="Session ID for conversation continuity")
+    session_id: Optional[str] = Field(
+        None, description="Session ID for conversation continuity"
+    )
     user_id: Optional[str] = Field(None, description="User identifier")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
-    search_type: SearchType = Field(default=SearchType.HYBRID, description="Type of search to perform")
-    
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional metadata"
+    )
+    search_type: SearchType = Field(
+        default=SearchType.HYBRID, description="Type of search to perform"
+    )
+
     model_config = ConfigDict(use_enum_values=True)
 
 
 class SearchRequest(BaseModel):
     """Search request model."""
+
     query: str = Field(..., description="Search query")
-    search_type: SearchType = Field(default=SearchType.HYBRID, description="Type of search")
+    search_type: SearchType = Field(
+        default=SearchType.HYBRID, description="Type of search"
+    )
     limit: int = Field(default=10, ge=1, le=50, description="Maximum results")
     filters: Dict[str, Any] = Field(default_factory=dict, description="Search filters")
-    
+
     model_config = ConfigDict(use_enum_values=True)
+
+
+class DocumentListRequest(BaseModel):
+    """Document listing request model."""
+
+    limit: int = Field(
+        default=20, ge=1, le=100, description="Maximum number of documents to return"
+    )
+    offset: int = Field(default=0, ge=0, description="Pagination offset")
 
 
 # Response Models
 class DocumentMetadata(BaseModel):
     """Document metadata model."""
+
     id: str
     title: str
     source: str
@@ -59,6 +81,7 @@ class DocumentMetadata(BaseModel):
 
 class ChunkResult(BaseModel):
     """Chunk search result model."""
+
     chunk_id: str
     document_id: str
     content: str
@@ -66,8 +89,8 @@ class ChunkResult(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
     document_title: str
     document_source: str
-    
-    @field_validator('score')
+
+    @field_validator("score")
     @classmethod
     def validate_score(cls, v: float) -> float:
         """Ensure score is between 0 and 1."""
@@ -76,6 +99,7 @@ class ChunkResult(BaseModel):
 
 class GraphSearchResult(BaseModel):
     """Knowledge graph search result model."""
+
     fact: str
     uuid: str
     valid_at: Optional[str] = None
@@ -85,6 +109,7 @@ class GraphSearchResult(BaseModel):
 
 class EntityRelationship(BaseModel):
     """Entity relationship model."""
+
     from_entity: str
     to_entity: str
     relationship_type: str
@@ -93,6 +118,7 @@ class EntityRelationship(BaseModel):
 
 class SearchResponse(BaseModel):
     """Search response model."""
+
     results: List[ChunkResult] = Field(default_factory=list)
     graph_results: List[GraphSearchResult] = Field(default_factory=list)
     total_results: int = 0
@@ -100,8 +126,18 @@ class SearchResponse(BaseModel):
     query_time_ms: float
 
 
+class DocumentListResponse(BaseModel):
+    """Document list response model."""
+
+    documents: List[DocumentMetadata] = Field(default_factory=list)
+    total: int
+    limit: int
+    offset: int
+
+
 class ToolCall(BaseModel):
     """Tool call information model."""
+
     tool_name: str
     args: Dict[str, Any] = Field(default_factory=dict)
     tool_call_id: Optional[str] = None
@@ -109,6 +145,7 @@ class ToolCall(BaseModel):
 
 class ChatResponse(BaseModel):
     """Chat response model."""
+
     message: str
     session_id: str
     sources: List[DocumentMetadata] = Field(default_factory=list)
@@ -118,6 +155,7 @@ class ChatResponse(BaseModel):
 
 class StreamDelta(BaseModel):
     """Streaming response delta."""
+
     content: str
     delta_type: Literal["text", "tool_call", "end"] = "text"
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -126,6 +164,7 @@ class StreamDelta(BaseModel):
 # Database Models
 class Document(BaseModel):
     """Document model."""
+
     id: Optional[str] = None
     title: str
     source: str
@@ -137,6 +176,7 @@ class Document(BaseModel):
 
 class Chunk(BaseModel):
     """Document chunk model."""
+
     id: Optional[str] = None
     document_id: str
     content: str
@@ -145,8 +185,8 @@ class Chunk(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
     token_count: Optional[int] = None
     created_at: Optional[datetime] = None
-    
-    @field_validator('embedding')
+
+    @field_validator("embedding")
     @classmethod
     def validate_embedding(cls, v: Optional[List[float]]) -> Optional[List[float]]:
         """Validate embedding dimensions."""
@@ -157,6 +197,7 @@ class Chunk(BaseModel):
 
 class Session(BaseModel):
     """Session model."""
+
     id: Optional[str] = None
     user_id: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -167,31 +208,32 @@ class Session(BaseModel):
 
 class Message(BaseModel):
     """Message model."""
+
     id: Optional[str] = None
     session_id: str
     role: MessageRole
     content: str
     metadata: Dict[str, Any] = Field(default_factory=dict)
     created_at: Optional[datetime] = None
-    
+
     model_config = ConfigDict(use_enum_values=True)
 
 
 # Agent Models
 class AgentDependencies(BaseModel):
     """Dependencies for the agent."""
+
     session_id: str
     database_url: Optional[str] = None
     neo4j_uri: Optional[str] = None
     openai_api_key: Optional[str] = None
-    
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
 
 
 class AgentContext(BaseModel):
     """Agent execution context."""
+
     session_id: str
     messages: List[Message] = Field(default_factory=list)
     tool_calls: List[ToolCall] = Field(default_factory=list)
@@ -203,26 +245,32 @@ class AgentContext(BaseModel):
 # Ingestion Models
 class IngestionConfig(BaseModel):
     """Configuration for document ingestion."""
+
     chunk_size: int = Field(default=1000, ge=100, le=5000)
     chunk_overlap: int = Field(default=200, ge=0, le=1000)
     max_chunk_size: int = Field(default=2000, ge=500, le=10000)
     use_semantic_chunking: bool = True
     extract_entities: bool = True
     # New option for faster ingestion
-    skip_graph_building: bool = Field(default=False, description="Skip knowledge graph building for faster ingestion")
-    
-    @field_validator('chunk_overlap')
+    skip_graph_building: bool = Field(
+        default=False, description="Skip knowledge graph building for faster ingestion"
+    )
+
+    @field_validator("chunk_overlap")
     @classmethod
     def validate_overlap(cls, v: int, info) -> int:
         """Ensure overlap is less than chunk size."""
-        chunk_size = info.data.get('chunk_size', 1000)
+        chunk_size = info.data.get("chunk_size", 1000)
         if v >= chunk_size:
-            raise ValueError(f"Chunk overlap ({v}) must be less than chunk size ({chunk_size})")
+            raise ValueError(
+                f"Chunk overlap ({v}) must be less than chunk size ({chunk_size})"
+            )
         return v
 
 
 class IngestionResult(BaseModel):
     """Result of document ingestion."""
+
     document_id: str
     title: str
     chunks_created: int
@@ -235,6 +283,7 @@ class IngestionResult(BaseModel):
 # Error Models
 class ErrorResponse(BaseModel):
     """Error response model."""
+
     error: str
     error_type: str
     details: Optional[Dict[str, Any]] = None
@@ -244,6 +293,7 @@ class ErrorResponse(BaseModel):
 # Health Check Models
 class HealthStatus(BaseModel):
     """Health check status."""
+
     status: Literal["healthy", "degraded", "unhealthy"]
     database: bool
     graph_database: bool

--- a/src/fastapi_app/tests/test_api.py
+++ b/src/fastapi_app/tests/test_api.py
@@ -1,9 +1,17 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch, AsyncMock, MagicMock
 import json
+from datetime import datetime
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("NEO4J_PASSWORD", "password")
+os.environ.setdefault("LLM_API_KEY", "test-key")
+os.environ.setdefault("EMBEDDING_API_KEY", "embed-key")
+
 from fastapi_app.api import app
-from fastapi_app.models import ChunkResult, GraphSearchResult
+from fastapi_app.models import ChunkResult, GraphSearchResult, DocumentMetadata
 
 # Use pytest-asyncio for async tests
 pytestmark = pytest.mark.asyncio
@@ -12,51 +20,102 @@ client = TestClient(app)
 
 # --- Mocks and Fixtures ---
 
+
 @pytest.fixture
 def mock_db_utils():
     """Mocks all functions in the db_utils module."""
-    with patch('fastapi_app.api.initialize_database', new_callable=AsyncMock) as mock_init_db, \
-         patch('fastapi_app.api.close_database', new_callable=AsyncMock) as mock_close_db, \
-         patch('fastapi_app.api.create_session', new_callable=AsyncMock, return_value="new-session-123") as mock_create, \
-         patch('fastapi_app.api.get_session', new_callable=AsyncMock, return_value={"id": "existing-session-456"}) as mock_get, \
-         patch('fastapi_app.api.add_message', new_callable=AsyncMock) as mock_add, \
-         patch('fastapi_app.api.get_session_messages', new_callable=AsyncMock, return_value=[]) as mock_get_messages, \
-         patch('fastapi_app.api.test_connection', new_callable=AsyncMock, return_value=True) as mock_test_conn:
+    with patch(
+        "fastapi_app.api.initialize_database", new_callable=AsyncMock
+    ) as mock_init_db, patch(
+        "fastapi_app.api.close_database", new_callable=AsyncMock
+    ) as mock_close_db, patch(
+        "fastapi_app.api.create_session",
+        new_callable=AsyncMock,
+        return_value="new-session-123",
+    ) as mock_create, patch(
+        "fastapi_app.api.get_session",
+        new_callable=AsyncMock,
+        return_value={"id": "existing-session-456"},
+    ) as mock_get, patch(
+        "fastapi_app.api.add_message", new_callable=AsyncMock
+    ) as mock_add, patch(
+        "fastapi_app.api.get_session_messages", new_callable=AsyncMock, return_value=[]
+    ) as mock_get_messages, patch(
+        "fastapi_app.api.test_connection", new_callable=AsyncMock, return_value=True
+    ) as mock_test_conn:
         yield {
             "create_session": mock_create,
             "get_session": mock_get,
             "add_message": mock_add,
-            "get_session_messages": mock_get_messages
+            "get_session_messages": mock_get_messages,
         }
+
 
 @pytest.fixture
 def mock_graph_utils():
     """Mocks all functions in the graph_utils module."""
-    with patch('fastapi_app.api.initialize_graph', new_callable=AsyncMock) as mock_init_graph, \
-         patch('fastapi_app.api.close_graph', new_callable=AsyncMock) as mock_close_graph, \
-         patch('fastapi_app.api.test_graph_connection', new_callable=AsyncMock, return_value=True) as mock_test_graph:
+    with patch(
+        "fastapi_app.api.initialize_graph", new_callable=AsyncMock
+    ) as mock_init_graph, patch(
+        "fastapi_app.api.close_graph", new_callable=AsyncMock
+    ) as mock_close_graph, patch(
+        "fastapi_app.api.test_graph_connection",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_test_graph:
         yield
+
 
 @pytest.fixture
 def mock_agent_execution():
     """Mocks the core agent execution logic."""
-    with patch('fastapi_app.api.execute_agent', new_callable=AsyncMock) as mock_execute:
-        mock_execute.return_value = ("Mocked AI response", [{"tool_name": "vector_search", "args": {"query": "Hello"}}])
+    with patch("fastapi_app.api.execute_agent", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = (
+            "Mocked AI response",
+            [{"tool_name": "vector_search", "args": {"query": "Hello"}}],
+        )
         yield mock_execute
+
 
 @pytest.fixture
 def mock_tools():
     """Mocks the individual search tools."""
-    with patch('fastapi_app.api.vector_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="vector search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_vector, \
-         patch('fastapi_app.api.graph_search_tool', new_callable=AsyncMock, return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")]) as mock_graph, \
-         patch('fastapi_app.api.hybrid_search_tool', new_callable=AsyncMock, return_value=[ChunkResult(chunk_id="1", document_id="doc1", content="hybrid search result", score=0.9, document_title="Doc 1", document_source="src1")]) as mock_hybrid:
-        yield {
-            "vector": mock_vector,
-            "graph": mock_graph,
-            "hybrid": mock_hybrid
-        }
+    with patch(
+        "fastapi_app.api.vector_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="vector search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_vector, patch(
+        "fastapi_app.api.graph_search_tool",
+        new_callable=AsyncMock,
+        return_value=[GraphSearchResult(fact="graph search result", uuid="uuid1")],
+    ) as mock_graph, patch(
+        "fastapi_app.api.hybrid_search_tool",
+        new_callable=AsyncMock,
+        return_value=[
+            ChunkResult(
+                chunk_id="1",
+                document_id="doc1",
+                content="hybrid search result",
+                score=0.9,
+                document_title="Doc 1",
+                document_source="src1",
+            )
+        ],
+    ) as mock_hybrid:
+        yield {"vector": mock_vector, "graph": mock_graph, "hybrid": mock_hybrid}
+
 
 # --- API Tests ---
+
 
 async def test_health_check(mock_db_utils, mock_graph_utils):
     response = client.get("/health")
@@ -66,16 +125,20 @@ async def test_health_check(mock_db_utils, mock_graph_utils):
     assert json_data["database"] is True
     assert json_data["graph_database"] is True
 
+
 async def test_chat_endpoint_creates_session(mock_db_utils, mock_agent_execution):
-    mock_db_utils["get_session"].return_value = None # Simulate no existing session
+    mock_db_utils["get_session"].return_value = None  # Simulate no existing session
     response = client.post("/chat", json={"message": "Hello"})
     assert response.status_code == 200
     mock_db_utils["create_session"].assert_called_once()
     mock_agent_execution.assert_called_once()
     assert response.json()["session_id"] == "new-session-123"
 
+
 async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_execution):
-    response = client.post("/chat", json={"message": "Hello again", "session_id": "existing-session-456"})
+    response = client.post(
+        "/chat", json={"message": "Hello again", "session_id": "existing-session-456"}
+    )
     assert response.status_code == 200
     mock_db_utils["get_session"].assert_called_with("existing-session-456")
     mock_db_utils["create_session"].assert_not_called()
@@ -83,26 +146,33 @@ async def test_chat_endpoint_uses_existing_session(mock_db_utils, mock_agent_exe
     assert response.json()["session_id"] == "existing-session-456"
     assert response.json()["tools_used"][0]["tool_name"] == "vector_search"
 
+
 async def test_chat_stream_endpoint(mock_db_utils):
     # Mock the agent's streaming logic
-    with patch('fastapi_app.api.rag_agent.iter') as mock_iter:
+    with patch("fastapi_app.api.rag_agent.iter") as mock_iter:
+
         async def mock_streamer(*args, **kwargs):
             yield f"data: {json.dumps({'type': 'session', 'session_id': 'stream-session-789'})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'Hello '})}\n\n"
             yield f"data: {json.dumps({'type': 'text', 'content': 'World!'})}\n\n"
             yield f"data: {json.dumps({'type': 'tools', 'tools': [{'tool_name': 'test_tool'}]})}\n\n"
             yield f"data: {json.dumps({'type': 'end'})}\n\n"
-        
-        mock_iter.return_value.__aenter__.return_value = mock_streamer() # type: ignore
-        
+
+        mock_iter.return_value.__aenter__.return_value = mock_streamer()  # type: ignore
+
         response = client.post("/chat/stream", json={"message": "stream test"})
         assert response.status_code == 200
         # In a real test client, you would iterate over the streaming response
         # Here we just confirm the endpoint is reachable and returns a streaming content type
         assert "text/event-stream" in response.headers["content-type"]
 
+
 async def test_vector_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
         response = client.post("/search/vector", json={"query": "test"})
         assert response.status_code == 200
         json_data = response.json()
@@ -110,6 +180,7 @@ async def test_vector_search_endpoint(mock_tools):
         assert len(json_data["results"]) == 1
         assert json_data["results"][0]["content"] == "vector search result"
         mock_tools["vector"].assert_called_once()
+
 
 async def test_graph_search_endpoint(mock_tools):
     response = client.post("/search/graph", json={"query": "test"})
@@ -120,8 +191,13 @@ async def test_graph_search_endpoint(mock_tools):
     assert json_data["graph_results"][0]["fact"] == "graph search result"
     mock_tools["graph"].assert_called_once()
 
+
 async def test_hybrid_search_endpoint(mock_tools):
-    with patch('fastapi_app.tools.generate_embedding', new_callable=AsyncMock, return_value=[0.1]*1536):
+    with patch(
+        "fastapi_app.tools.generate_embedding",
+        new_callable=AsyncMock,
+        return_value=[0.1] * 1536,
+    ):
         response = client.post("/search/hybrid", json={"query": "test"})
         assert response.status_code == 200
         json_data = response.json()
@@ -129,3 +205,39 @@ async def test_hybrid_search_endpoint(mock_tools):
         assert len(json_data["results"]) == 1
         assert json_data["results"][0]["content"] == "hybrid search result"
         mock_tools["hybrid"].assert_called_once()
+
+
+async def test_list_documents_endpoint():
+    doc = DocumentMetadata(
+        id="doc1",
+        title="Doc 1",
+        source="src1",
+        metadata={},
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    with patch(
+        "fastapi_app.api.list_documents_tool",
+        new_callable=AsyncMock,
+        return_value=[doc],
+    ) as mock_list:
+        response = client.get("/documents")
+        assert response.status_code == 200
+        json_data = response.json()
+        assert json_data["total"] == 1
+        assert json_data["documents"][0]["id"] == "doc1"
+        mock_list.assert_called_once()
+
+
+async def test_get_session_info_endpoint(mock_db_utils):
+    mock_db_utils["get_session"].return_value = {
+        "id": "session-123",
+        "user_id": "user1",
+        "metadata": {},
+        "created_at": datetime.now().isoformat(),
+        "updated_at": datetime.now().isoformat(),
+    }
+    response = client.get("/sessions/session-123")
+    assert response.status_code == 200
+    assert response.json()["id"] == "session-123"
+    mock_db_utils["get_session"].assert_called_with("session-123")


### PR DESCRIPTION
## Summary
- add document listing request and response models
- use response models for search, document, and session endpoints
- extend API tests with environment setup and new cases

## Testing
- `pytest src/fastapi_app/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68994f847df0832ab7eb4c666bc35d2b