### PR TITLE
Add auth dependency to chat and search endpoints

### DIFF
--- a/DIFF_20250811_020743.md
+++ b/DIFF_20250811_020743.md
@@ -1,0 +1,19 @@
+## Changes on ${timestamp}
+
+- Added simple bearer token verification and auth dependency.
+- Protected `/chat`, `/chat/stream`, and `/search/*` endpoints with authentication.
+- Created `verify_token` in `db_utils.py` for placeholder token validation.
+- Updated tests to include Authorization headers and environment setup; added unauthorized test.
+
+## Changes on 20250811_020743 (corrected)
+
+- Added simple bearer token verification and auth dependency.
+- Protected , , and  endpoints with authentication.
+- Created  in  for placeholder token validation.
+- Updated tests to include Authorization headers and environment setup; added unauthorized test.
+
+## Changes on 20250811_020743 (correction 2)
+- Added simple bearer token verification and auth dependency.
+- Protected /chat, /chat/stream, and /search/* endpoints with authentication.
+- Created verify_token in db_utils.py for placeholder token validation.
+- Updated tests to include Authorization headers and environment setup; added unauthorized test.

--- a/RECOMMENDATIONS_20250811_020743.md
+++ b/RECOMMENDATIONS_20250811_020743.md
@@ -1,0 +1,4 @@
+## Recommendations on 20250811_020743
+
+- Replace placeholder token verification with integration to Supabase or OAuth provider.
+- Centralize environment setup for tests to avoid repetition across modules.

--- a/src/fastapi_app/db_utils.py
+++ b/src/fastapi_app/db_utils.py
@@ -75,6 +75,15 @@ async def initialize_database():
     await db_pool.initialize()
 
 
+# Authentication utilities
+API_AUTH_TOKEN = os.getenv("API_AUTH_TOKEN", "test-token")
+
+
+async def verify_token(token: str) -> bool:
+    """Verify bearer token for authentication."""
+    return token == API_AUTH_TOKEN
+
+
 async def close_database():
     """Close database connection pool."""
     await db_pool.close()


### PR DESCRIPTION
## Summary
- enforce bearer-token authentication via reusable dependency
- require auth for chat, streaming chat, and search endpoints
- cover authenticated and unauthenticated cases in API tests

## Testing
- `pytest src/fastapi_app/tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68994f86e2f0832a950b6a652a1f7d01