### PR TITLE
Use logger and runtime error for provider configuration

### DIFF
--- a/DIFF_20250811_020835.md
+++ b/DIFF_20250811_020835.md
@@ -1,0 +1,4 @@
+## Changes on 2025-08-11 02:08:35
+- add logging to providers module and replace print with logger.error
+- raise RuntimeError for missing configuration instead of returning False
+- update tests to handle RuntimeError expectation

--- a/RECOMMENDATIONS_20250811_020835.md
+++ b/RECOMMENDATIONS_20250811_020835.md
@@ -1,0 +1,3 @@
+## Recommendations on 2025-08-11 02:08:35
+- consider consolidating configuration validation across modules to avoid duplication.
+- add unit tests for other provider functions to ensure full coverage.

--- a/src/fastapi_app/providers.py
+++ b/src/fastapi_app/providers.py
@@ -91,7 +91,7 @@ def validate_configuration() -> bool:
     Validate that required environment variables are set.
 
     Returns:
-        True if configuration is valid
+        True if all required configuration is present
 
     Raises:
         RuntimeError: If required configuration is missing.

--- a/src/fastapi_app/providers.py
+++ b/src/fastapi_app/providers.py
@@ -3,11 +3,13 @@ Flexible provider configuration for LLM and embedding models.
 """
 
 import os
+import logging
 from typing import Optional
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.openai import OpenAIModel
 import openai
 from dotenv import load_dotenv
+logger = logging.getLogger(__name__)
 
 # Load environment variables
 load_dotenv()
@@ -87,9 +89,12 @@ def get_embedding_provider() -> str:
 def validate_configuration() -> bool:
     """
     Validate that required environment variables are set.
-    
+
     Returns:
         True if configuration is valid
+
+    Raises:
+        RuntimeError: If required configuration is missing.
     """
     required_vars = [
         'LLM_API_KEY',
@@ -97,18 +102,18 @@ def validate_configuration() -> bool:
         'EMBEDDING_API_KEY',
         'EMBEDDING_MODEL'
     ]
-    
+
     missing_vars = []
     for var in required_vars:
         if not os.getenv(var):
             missing_vars.append(var)
-    
-    if missing_vars:
-        print(f"Missing required environment variables: {', '.join(missing_vars)}")
-        return False
-    
-    return True
 
+    if missing_vars:
+        msg = f"Missing required environment variables: {', '.join(missing_vars)}"
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    return True
 
 def get_model_info() -> dict:
     """

--- a/src/fastapi_app/tests/test_providers.py
+++ b/src/fastapi_app/tests/test_providers.py
@@ -42,4 +42,5 @@ def test_validate_configuration_success():
 def test_validate_configuration_failure():
     """Tests that validation fails when env vars are missing."""
     with patch.dict(os.environ, {}, clear=True):
-        assert validate_configuration() is False
+        with pytest.raises(RuntimeError):
+            validate_configuration()


### PR DESCRIPTION
## Summary
- replace print with logger.error and raise RuntimeError on missing provider configuration
- adjust tests to expect RuntimeError when configuration is incomplete

## Testing
- `pytest` *(fails: SyntaxError: invalid syntax in tests/test_ingestion.py)*
- `pytest src/fastapi_app/tests/test_providers.py`


------
https://chatgpt.com/codex/tasks/task_e_68994f8e86dc832aa1ebea58c0c342bd

## Summary by Sourcery

Replace print-based error handling in provider configuration with logging and exceptions, and adjust tests accordingly

Enhancements:
- Use logger.error instead of print in validate_configuration
- Raise RuntimeError when required environment variables are missing

Tests:
- Update configuration validation tests to expect RuntimeError on missing variables