### PR TITLE
feat(api): configurable cors origins

### DIFF
--- a/DIFF_20250811_020725.md
+++ b/DIFF_20250811_020725.md
@@ -1,0 +1,5 @@
+## Changes on 2025-08-11 02:07:25 UTC
+
+- Introduced `ALLOWED_ORIGINS` environment variable parsed into a list and applied to CORS middleware.
+- Added documentation for `ALLOWED_ORIGINS` in `README.md`.
+- Created tests validating CORS configuration via `ALLOWED_ORIGINS`.

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ Your application is now fully deployed and operational!
 -   **LLM Observability (Langfuse):** `https://langfuse.your-domain.com`
 -   **Observability (Jaeger):** `https://jaeger.your-domain.com`
 -   **Traefik Dashboard:** `https://traefik.your-domain.com`
+
+## Environment Variables
+
+-   `ALLOWED_ORIGINS`: Comma-separated list of origins permitted for CORS requests to the FastAPI backend. Defaults to disallow all cross-origin requests.

--- a/RECOMMENDATIONS_20250811_020725.md
+++ b/RECOMMENDATIONS_20250811_020725.md
@@ -1,0 +1,4 @@
+## Recommendations on 2025-08-11 02:07:25 UTC
+
+- Add validation to warn when `ALLOWED_ORIGINS` is empty to prevent accidental open exposure in deployment.
+- Include sample values for `ALLOWED_ORIGINS` in deployment scripts or environment templates for clarity.

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -91,6 +91,11 @@ APP_ENV = os.getenv("APP_ENV", "development")
 APP_HOST = os.getenv("APP_HOST", "0.0.0.0")
 APP_PORT = int(os.getenv("APP_PORT", 8000))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+ALLOWED_ORIGINS: List[str] = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
+    if origin.strip()
+]
 
 # Configure logging
 logging.basicConfig(
@@ -160,7 +165,7 @@ FastAPIInstrumentor.instrument_app(app)
 # Add middleware with flexible CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/fastapi_app/tests/test_cors.py
+++ b/src/fastapi_app/tests/test_cors.py
@@ -35,4 +35,15 @@ def test_cors_env_allows_list(monkeypatch):
         "https://foo.com",
     ]
     # Reset module to default state for other tests
-    _reload_api(monkeypatch)
+def test_cors_default_blocks(api_module_fixture):
+    api_module = api_module_fixture
+    assert _get_cors_origins(api_module.app) == []
+
+
+@pytest.mark.parametrize("api_module_fixture", ["https://example.com, https://foo.com"], indirect=True)
+def test_cors_env_allows_list(api_module_fixture):
+    api_module = api_module_fixture
+    assert _get_cors_origins(api_module.app) == [
+        "https://example.com",
+        "https://foo.com",
+    ]

--- a/src/fastapi_app/tests/test_cors.py
+++ b/src/fastapi_app/tests/test_cors.py
@@ -1,0 +1,38 @@
+import importlib
+import pytest
+
+
+def _reload_api(monkeypatch, origins=None):
+    if origins is None:
+        monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    else:
+        monkeypatch.setenv("ALLOWED_ORIGINS", origins)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/db")
+    monkeypatch.setenv("NEO4J_PASSWORD", "dummy")
+    monkeypatch.setenv("LLM_API_KEY", "dummy")
+    monkeypatch.setenv("EMBEDDING_API_KEY", "dummy")
+    import fastapi_app.api as api_module
+    importlib.reload(api_module)
+    return api_module
+
+
+def _get_cors_origins(app):
+    for m in app.user_middleware:
+        if m.cls.__name__ == "CORSMiddleware":
+            return m.kwargs.get("allow_origins")
+    return None
+
+
+def test_cors_default_blocks(monkeypatch):
+    api_module = _reload_api(monkeypatch)
+    assert _get_cors_origins(api_module.app) == []
+
+
+def test_cors_env_allows_list(monkeypatch):
+    api_module = _reload_api(monkeypatch, "https://example.com, https://foo.com")
+    assert _get_cors_origins(api_module.app) == [
+        "https://example.com",
+        "https://foo.com",
+    ]
+    # Reset module to default state for other tests
+    _reload_api(monkeypatch)


### PR DESCRIPTION
## Summary
- allow configuring FastAPI CORS origins via `ALLOWED_ORIGINS` env var
- document `ALLOWED_ORIGINS` in README
- test that CORS configuration honours the env var and defaults to blocking all origins

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*
- `pytest src/fastapi_app/tests/test_cors.py -q`
- `pytest tests/test_environment.py -q`
- `pytest tests/test_shellcheck.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68994f903cfc832ab37eae165df8d1e1

## Summary by Sourcery

Introduce a new ALLOWED_ORIGINS environment variable to configure FastAPI CORS settings, defaulting to no origins, update documentation accordingly, and add tests to verify the behavior.

New Features:
- Make CORS origins configurable via ALLOWED_ORIGINS environment variable

Documentation:
- Document ALLOWED_ORIGINS setting in README under Environment Variables

Tests:
- Add tests to ensure default CORS blocks all origins and correctly parses custom origins from ALLOWED_ORIGINS