### PR TITLE
Use JSONResponse for global exception handler

### DIFF
--- a/DIFF_20250811_020711.md
+++ b/DIFF_20250811_020711.md
@@ -1,0 +1,3 @@
+## 2025-08-11T02:07:11Z
+- Updated `src/fastapi_app/api.py` global exception handler to return `JSONResponse` with request ID and error details.
+- Imported `JSONResponse` in `src/fastapi_app/api.py`.

--- a/RECOMMENDATIONS_20250811_020711.md
+++ b/RECOMMENDATIONS_20250811_020711.md
@@ -1,0 +1,3 @@
+## 2025-08-11T02:07:11Z
+- Add automated tests for the global exception handler to ensure JSON responses include request IDs and details.
+- Consider extending error details with trace identifiers for improved observability.

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import uuid
 
 from fastapi import FastAPI, HTTPException, Request, Depends
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 import uvicorn
@@ -673,10 +673,19 @@ async def get_session_info(session_id: str):
 async def global_exception_handler(request: Request, exc: Exception):
     """Global exception handler."""
     logger.error(f"Unhandled exception: {exc}")
+    request_id = str(uuid.uuid4())
+    details = getattr(exc, "detail", None)
+    if details is not None and not isinstance(details, dict):
+        details = {"detail": details}
 
-    return ErrorResponse(
-        error=str(exc), error_type=type(exc).__name__, request_id=str(uuid.uuid4())
+    error_response = ErrorResponse(
+        error=str(exc),
+        error_type=type(exc).__name__,
+        details=details,
+        request_id=request_id,
     )
+
+    return JSONResponse(status_code=500, content=error_response.model_dump())
 
 
 # Development server


### PR DESCRIPTION
## Summary
- return structured JSON responses for uncaught exceptions, including request IDs and details
- document changes and recommendations

## Testing
- `pre-commit run --files src/fastapi_app/api.py DIFF_20250811_020711.md RECOMMENDATIONS_20250811_020711.md`
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py)*

------
https://chatgpt.com/codex/tasks/task_e_68994f91dbec832ab6a2010633533ea9

## Summary by Sourcery

Use JSONResponse in the global exception handler to return structured JSON errors with a generated request ID and exception details, and add documentation and recommendations markdown files.

New Features:
- Switch global exception handler to return a JSONResponse containing error, error type, details, and a unique request ID
- Extract and normalize exception.detail into a dictionary when present

Documentation:
- Add DIFF_20250811_020711.md documenting handler changes
- Add RECOMMENDATIONS_20250811_020711.md with testing and observability suggestions

Tests:
- Recommend adding automated tests for the global exception handler to verify JSON responses