### PR TITLE
Handle errors in chat stream

### DIFF
--- a/DIFF_20250811_020731.md
+++ b/DIFF_20250811_020731.md
@@ -1,0 +1,4 @@
+## Changes on 2025-08-11 at 02:07:31
+- Wrapped the body of `generate_stream` in `try/except/finally` to ensure robust error handling and cleanup.
+- On exceptions, the stream now yields an `error` SSE event containing the message.
+- Added a `finally` block to close any partially started runs and always send a terminating `end` event.

--- a/RECOMMENDATIONS_20250811_020731.md
+++ b/RECOMMENDATIONS_20250811_020731.md
@@ -1,0 +1,3 @@
+## Recommendations as of 2025-08-11 02:07:31
+- Add unit tests to verify that the stream emits an `error` event when exceptions occur and that a final `end` event is always sent.
+- Consider centralizing test environment configuration to avoid manual environment variable setup when running individual test files.


### PR DESCRIPTION
## Summary
- wrap chat stream generator in try/except/finally
- emit SSE `error` events and always close runs
- document stream handler changes

## Testing
- `pytest src/fastapi_app/tests/test_api.py::test_chat_stream_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68994f8d7f34832a8cbe0a5bfe460e9f

## Summary by Sourcery

Enhance the chat_stream endpoint with robust error handling, SSE error events, guaranteed cleanup of runs, and consistent end-of-stream signaling.

Enhancements:
- Wrap the chat stream generator in a try/except/finally block to manage exceptions and resource cleanup
- Emit SSE ‘error’ events when exceptions occur during streaming
- Ensure any partially started run is closed in the finally block
- Always yield a terminating ‘end’ event to signal stream completion, even after errors

Documentation:
- Add DIFF_... and RECOMMENDATIONS_... markdown files capturing change logs and testing recommendations