### PR TITLE
refactor: centralize env settings with pydantic

### DIFF
--- a/DIFF_20250811_020911.md
+++ b/DIFF_20250811_020911.md
@@ -1,0 +1,8 @@
+# Diff Report 2025-08-11 02:09:11
+
+- Added `src/settings.py` to centralize environment configuration using `pydantic.BaseSettings` and fail fast on missing `LLM_API_KEY` or `DATABASE_URL`.
+- Added `agentic-rag-knowledge-graph/settings.py` mirroring global settings for the subproject.
+- Replaced `load_dotenv` and direct `os.getenv` calls across FastAPI modules (`src/fastapi_app/api.py`, `providers.py`, `db_utils.py`, `graph_utils.py`, `tools.py`, `agent.py`).
+- Updated ingestion utilities (`src/ingestion/embedder.py`, `chunker.py`, `graph_builder.py`, `ingest.py`) to remove dotenv usage.
+- Mirrored the same refactor for the `agentic-rag-knowledge-graph` subset (`agent/*.py` and `ingestion/*.py`).
+- Ensured all modules import and use the shared `settings` instance for configuration.

--- a/RECOMMENDATIONS_20250811_020911.md
+++ b/RECOMMENDATIONS_20250811_020911.md
@@ -1,0 +1,5 @@
+# Recommendations 2025-08-11 02:09:11
+
+- Consider adding integration tests that mock external services to validate the new settings-based configuration without requiring live databases or APIs.
+- Document required environment variables in README to help developers understand the fail-fast behavior.
+- Explore centralizing duplicate code between `src` and `agentic-rag-knowledge-graph` to avoid maintaining parallel modules.

--- a/agentic-rag-knowledge-graph/agent/agent.py
+++ b/agentic-rag-knowledge-graph/agent/agent.py
@@ -1,14 +1,10 @@
-"""
-Main Pydantic AI agent for agentic RAG with knowledge graph.
-"""
+"""Main Pydantic AI agent for agentic RAG with knowledge graph."""
 
-import os
 import logging
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext
-from dotenv import load_dotenv
 
 from .prompts import SYSTEM_PROMPT
 from .providers import get_llm_model
@@ -28,9 +24,6 @@ from .tools import (
     EntityRelationshipInput,
     EntityTimelineInput
 )
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/agent/api.py
+++ b/agentic-rag-knowledge-graph/agent/api.py
@@ -1,8 +1,5 @@
-"""
-FastAPI endpoints for the agentic RAG system.
-"""
+"""FastAPI endpoints for the agentic RAG system."""
 
-import os
 import asyncio
 import json
 import logging
@@ -16,7 +13,8 @@ from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 import uvicorn
-from dotenv import load_dotenv
+
+from ..settings import settings
 
 from .agent import rag_agent, AgentDependencies
 from .db_utils import (
@@ -50,16 +48,13 @@ from .tools import (
     DocumentListInput
 )
 
-# Load environment variables
-load_dotenv()
-
 logger = logging.getLogger(__name__)
 
 # Application configuration
-APP_ENV = os.getenv("APP_ENV", "development")
-APP_HOST = os.getenv("APP_HOST", "0.0.0.0")
-APP_PORT = int(os.getenv("APP_PORT", 8000))
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+APP_ENV = settings.app_env
+APP_HOST = settings.app_host
+APP_PORT = settings.app_port
+LOG_LEVEL = settings.log_level
 
 # Configure logging
 logging.basicConfig(

--- a/agentic-rag-knowledge-graph/agent/db_utils.py
+++ b/agentic-rag-knowledge-graph/agent/db_utils.py
@@ -2,7 +2,6 @@
 Database utilities for PostgreSQL connection and operations.
 """
 
-import os
 import json
 import asyncio
 from typing import List, Dict, Any, Optional, Tuple
@@ -13,10 +12,8 @@ import logging
 
 import asyncpg
 from asyncpg.pool import Pool
-from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv()
+from ..settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +28,7 @@ class DatabasePool:
         Args:
             database_url: PostgreSQL connection URL
         """
-        self.database_url = database_url or os.getenv("DATABASE_URL")
+        self.database_url = database_url or settings.database_url
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable not set")
         

--- a/agentic-rag-knowledge-graph/agent/graph_utils.py
+++ b/agentic-rag-knowledge-graph/agent/graph_utils.py
@@ -1,8 +1,5 @@
-"""
-Graph utilities for Neo4j/Graphiti integration.
-"""
+"""Graph utilities for Neo4j/Graphiti integration."""
 
-import os
 import json
 import logging
 from typing import List, Dict, Any, Optional, Tuple
@@ -16,10 +13,8 @@ from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.llm_client.openai_client import OpenAIClient
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
-from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv()
+from ..settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -42,27 +37,27 @@ class GraphitiClient:
             neo4j_password: Neo4j password
         """
         # Neo4j configuration
-        self.neo4j_uri = neo4j_uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
-        self.neo4j_user = neo4j_user or os.getenv("NEO4J_USER", "neo4j")
-        self.neo4j_password = neo4j_password or os.getenv("NEO4J_PASSWORD")
+        self.neo4j_uri = neo4j_uri or settings.neo4j_uri
+        self.neo4j_user = neo4j_user or settings.neo4j_user
+        self.neo4j_password = neo4j_password or settings.neo4j_password
         
         if not self.neo4j_password:
             raise ValueError("NEO4J_PASSWORD environment variable not set")
         
         # LLM configuration
-        self.llm_base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1")
-        self.llm_api_key = os.getenv("LLM_API_KEY")
-        self.llm_choice = os.getenv("LLM_CHOICE", "gpt-4.1-mini")
+        self.llm_base_url = settings.llm_base_url
+        self.llm_api_key = settings.llm_api_key
+        self.llm_choice = settings.llm_choice
         
         if not self.llm_api_key:
             raise ValueError("LLM_API_KEY environment variable not set")
         
         # Embedding configuration
-        self.embedding_base_url = os.getenv("EMBEDDING_BASE_URL", "https://api.openai.com/v1")
-        self.embedding_api_key = os.getenv("EMBEDDING_API_KEY")
-        self.embedding_model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
-        self.embedding_dimensions = int(os.getenv("VECTOR_DIMENSION", "1536"))
-        
+        self.embedding_base_url = settings.embedding_base_url
+        self.embedding_api_key = settings.embedding_api_key or settings.llm_api_key
+        self.embedding_model = settings.embedding_model
+        self.embedding_dimensions = settings.vector_dimension
+
         if not self.embedding_api_key:
             raise ValueError("EMBEDDING_API_KEY environment variable not set")
         

--- a/agentic-rag-knowledge-graph/agent/providers.py
+++ b/agentic-rag-knowledge-graph/agent/providers.py
@@ -1,16 +1,11 @@
-"""
-Flexible provider configuration for LLM and embedding models.
-"""
+"""Flexible provider configuration for LLM and embedding models."""
 
-import os
 from typing import Optional
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.openai import OpenAIModel
 import openai
-from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv()
+from ..settings import settings
 
 
 def get_llm_model(model_choice: Optional[str] = None) -> OpenAIModel:
@@ -23,9 +18,9 @@ def get_llm_model(model_choice: Optional[str] = None) -> OpenAIModel:
     Returns:
         Configured OpenAI-compatible model
     """
-    llm_choice = model_choice or os.getenv('LLM_CHOICE', 'gpt-4-turbo-preview')
-    base_url = os.getenv('LLM_BASE_URL', 'https://api.openai.com/v1')
-    api_key = os.getenv('LLM_API_KEY', 'ollama')
+    llm_choice = model_choice or settings.llm_choice
+    base_url = settings.llm_base_url
+    api_key = settings.llm_api_key
     
     provider = OpenAIProvider(base_url=base_url, api_key=api_key)
     return OpenAIModel(llm_choice, provider=provider)
@@ -38,8 +33,8 @@ def get_embedding_client() -> openai.AsyncOpenAI:
     Returns:
         Configured OpenAI-compatible client for embeddings
     """
-    base_url = os.getenv('EMBEDDING_BASE_URL', 'https://api.openai.com/v1')
-    api_key = os.getenv('EMBEDDING_API_KEY', 'ollama')
+    base_url = settings.embedding_base_url
+    api_key = settings.embedding_api_key or settings.llm_api_key
     
     return openai.AsyncOpenAI(
         base_url=base_url,
@@ -54,7 +49,7 @@ def get_embedding_model() -> str:
     Returns:
         Embedding model name
     """
-    return os.getenv('EMBEDDING_MODEL', 'text-embedding-3-small')
+    return settings.embedding_model
 
 
 def get_ingestion_model() -> OpenAIModel:
@@ -64,7 +59,7 @@ def get_ingestion_model() -> OpenAIModel:
     Returns:
         Configured model for ingestion tasks
     """
-    ingestion_choice = os.getenv('INGESTION_LLM_CHOICE')
+    ingestion_choice = settings.ingestion_llm_choice
     
     # If no specific ingestion model, use the main model
     if not ingestion_choice:
@@ -76,12 +71,12 @@ def get_ingestion_model() -> OpenAIModel:
 # Provider information functions
 def get_llm_provider() -> str:
     """Get the LLM provider name."""
-    return os.getenv('LLM_PROVIDER', 'openai')
+    return settings.llm_provider
 
 
 def get_embedding_provider() -> str:
     """Get the embedding provider name."""
-    return os.getenv('EMBEDDING_PROVIDER', 'openai')
+    return settings.embedding_provider
 
 
 def validate_configuration() -> bool:
@@ -91,17 +86,14 @@ def validate_configuration() -> bool:
     Returns:
         True if configuration is valid
     """
-    required_vars = [
-        'LLM_API_KEY',
-        'LLM_CHOICE',
-        'EMBEDDING_API_KEY',
-        'EMBEDDING_MODEL'
-    ]
-    
-    missing_vars = []
-    for var in required_vars:
-        if not os.getenv(var):
-            missing_vars.append(var)
+    required_vars = {
+        'LLM_API_KEY': settings.llm_api_key,
+        'LLM_CHOICE': settings.llm_choice,
+        'EMBEDDING_API_KEY': settings.embedding_api_key or settings.llm_api_key,
+        'EMBEDDING_MODEL': settings.embedding_model,
+    }
+
+    missing_vars = [name for name, value in required_vars.items() if not value]
     
     if missing_vars:
         print(f"Missing required environment variables: {', '.join(missing_vars)}")
@@ -119,10 +111,10 @@ def get_model_info() -> dict:
     """
     return {
         "llm_provider": get_llm_provider(),
-        "llm_model": os.getenv('LLM_CHOICE'),
-        "llm_base_url": os.getenv('LLM_BASE_URL'),
+        "llm_model": settings.llm_choice,
+        "llm_base_url": settings.llm_base_url,
         "embedding_provider": get_embedding_provider(),
         "embedding_model": get_embedding_model(),
-        "embedding_base_url": os.getenv('EMBEDDING_BASE_URL'),
-        "ingestion_model": os.getenv('INGESTION_LLM_CHOICE', 'same as main'),
+        "embedding_base_url": settings.embedding_base_url,
+        "ingestion_model": settings.ingestion_llm_choice or 'same as main',
     }

--- a/agentic-rag-knowledge-graph/agent/tools.py
+++ b/agentic-rag-knowledge-graph/agent/tools.py
@@ -1,15 +1,11 @@
-"""
-Tools for the Pydantic AI agent.
-"""
+"""Tools for the Pydantic AI agent."""
 
-import os
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 import asyncio
 
 from pydantic import BaseModel, Field
-from dotenv import load_dotenv
 
 from .db_utils import (
     vector_search,
@@ -25,9 +21,6 @@ from .graph_utils import (
 )
 from .models import ChunkResult, GraphSearchResult, DocumentMetadata
 from .providers import get_embedding_client, get_embedding_model
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/ingestion/chunker.py
+++ b/agentic-rag-knowledge-graph/ingestion/chunker.py
@@ -1,18 +1,10 @@
-"""
-Semantic chunking implementation for intelligent document splitting.
-"""
+"""Semantic chunking implementation for intelligent document splitting."""
 
-import os
 import re
 import logging
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass
 import asyncio
-
-from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/ingestion/embedder.py
+++ b/agentic-rag-knowledge-graph/ingestion/embedder.py
@@ -1,8 +1,5 @@
-"""
-Document embedding generation for vector search.
-"""
+"""Document embedding generation for vector search."""
 
-import os
 import asyncio
 import logging
 from typing import List, Dict, Any, Optional, Tuple
@@ -10,7 +7,6 @@ from datetime import datetime
 import json
 
 from openai import RateLimitError, APIError
-from dotenv import load_dotenv
 
 from .chunker import DocumentChunk
 
@@ -23,9 +19,6 @@ except ImportError:
     import os
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from agent.providers import get_embedding_client, get_embedding_model
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/ingestion/graph_builder.py
+++ b/agentic-rag-knowledge-graph/ingestion/graph_builder.py
@@ -1,8 +1,5 @@
-"""
-Knowledge graph builder for extracting entities and relationships.
-"""
+"""Knowledge graph builder for extracting entities and relationships."""
 
-import os
 import logging
 from typing import List, Dict, Any, Optional, Set, Tuple
 from datetime import datetime, timezone
@@ -10,7 +7,6 @@ import asyncio
 import re
 
 from graphiti_core import Graphiti
-from dotenv import load_dotenv
 
 from .chunker import DocumentChunk
 
@@ -23,9 +19,6 @@ except ImportError:
     import os
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from agent.graph_utils import GraphitiClient
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/ingestion/ingest.py
+++ b/agentic-rag-knowledge-graph/ingestion/ingest.py
@@ -13,7 +13,6 @@ from datetime import datetime
 import argparse
 
 import asyncpg
-from dotenv import load_dotenv
 
 from .chunker import ChunkingConfig, create_chunker, DocumentChunk
 from .embedder import create_embedder
@@ -32,9 +31,6 @@ except ImportError:
     from agent.db_utils import initialize_database, close_database, db_pool
     from agent.graph_utils import initialize_graph, close_graph
     from agent.models import IngestionConfig, IngestionResult
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/agentic-rag-knowledge-graph/settings.py
+++ b/agentic-rag-knowledge-graph/settings.py
@@ -1,0 +1,35 @@
+from pydantic import BaseSettings, Field
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    llm_api_key: str = Field(..., env="LLM_API_KEY")
+    database_url: str = Field(..., env="DATABASE_URL")
+
+    llm_choice: str = Field("gpt-4-turbo-preview", env="LLM_CHOICE")
+    llm_base_url: str = Field("https://api.openai.com/v1", env="LLM_BASE_URL")
+    llm_provider: str = Field("openai", env="LLM_PROVIDER")
+
+    embedding_api_key: str | None = Field(None, env="EMBEDDING_API_KEY")
+    embedding_base_url: str = Field("https://api.openai.com/v1", env="EMBEDDING_BASE_URL")
+    embedding_model: str = Field("text-embedding-3-small", env="EMBEDDING_MODEL")
+    embedding_provider: str = Field("openai", env="EMBEDDING_PROVIDER")
+
+    ingestion_llm_choice: str | None = Field(None, env="INGESTION_LLM_CHOICE")
+
+    app_env: str = Field("development", env="APP_ENV")
+    app_host: str = Field("0.0.0.0", env="APP_HOST")
+    app_port: int = Field(8000, env="APP_PORT")
+    log_level: str = Field("INFO", env="LOG_LEVEL")
+
+    neo4j_uri: str = Field("bolt://localhost:7687", env="NEO4J_URI")
+    neo4j_user: str = Field("neo4j", env="NEO4J_USER")
+    neo4j_password: str | None = Field(None, env="NEO4J_PASSWORD")
+
+    vector_dimension: int = Field(1536, env="VECTOR_DIMENSION")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+settings = Settings()

--- a/src/fastapi_app/agent.py
+++ b/src/fastapi_app/agent.py
@@ -8,7 +8,6 @@ from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
 
 from pydantic_ai import Agent, RunContext
-from dotenv import load_dotenv
 
 from fastapi_app.prompts import SYSTEM_PROMPT
 from fastapi_app.providers import get_llm_model
@@ -28,9 +27,6 @@ from fastapi_app.tools import (
     EntityRelationshipInput,
     EntityTimelineInput
 )
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -1,8 +1,5 @@
-"""
-FastAPI endpoints for the agentic RAG system.
-"""
+"""FastAPI endpoints for the agentic RAG system."""
 
-import os
 import asyncio
 import json
 import logging
@@ -16,7 +13,8 @@ from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 import uvicorn
-from dotenv import load_dotenv
+
+from settings import settings
 
 from fastapi_app.agent import rag_agent, AgentDependencies
 from fastapi_app.db_utils import (
@@ -80,17 +78,14 @@ langfuse = Langfuse()
 
 # --- End OpenTelemetry ---
 
-# Load environment variables
-load_dotenv()
-
 logger = logging.getLogger(__name__)
 
 
 # Application configuration
-APP_ENV = os.getenv("APP_ENV", "development")
-APP_HOST = os.getenv("APP_HOST", "0.0.0.0")
-APP_PORT = int(os.getenv("APP_PORT", 8000))
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+APP_ENV = settings.app_env
+APP_HOST = settings.app_host
+APP_PORT = settings.app_port
+LOG_LEVEL = settings.log_level
 
 # Configure logging
 logging.basicConfig(

--- a/src/fastapi_app/db_utils.py
+++ b/src/fastapi_app/db_utils.py
@@ -1,8 +1,5 @@
-"""
-Database utilities for PostgreSQL connection and operations.
-"""
+"""Database utilities for PostgreSQL connection and operations."""
 
-import os
 import json
 import asyncio
 from typing import List, Dict, Any, Optional, Tuple
@@ -13,10 +10,7 @@ import logging
 
 import asyncpg
 from asyncpg.pool import Pool
-from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv()
+from settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +25,7 @@ class DatabasePool:
         Args:
             database_url: PostgreSQL connection URL
         """
-        self.database_url = database_url or os.getenv("DATABASE_URL")
+        self.database_url = database_url or settings.database_url
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable not set")
         

--- a/src/fastapi_app/graph_utils.py
+++ b/src/fastapi_app/graph_utils.py
@@ -1,8 +1,5 @@
-"""
-Graph utilities for Neo4j/Graphiti integration.
-"""
+"""Graph utilities for Neo4j/Graphiti integration."""
 
-import os
 import json
 import logging
 from typing import List, Dict, Any, Optional, Tuple
@@ -16,10 +13,8 @@ from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.llm_client.openai_client import OpenAIClient
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
-from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv()
+from settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -42,27 +37,27 @@ class GraphitiClient:
             neo4j_password: Neo4j password
         """
         # Neo4j configuration
-        self.neo4j_uri = neo4j_uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
-        self.neo4j_user = neo4j_user or os.getenv("NEO4J_USER", "neo4j")
-        self.neo4j_password = neo4j_password or os.getenv("NEO4J_PASSWORD")
+        self.neo4j_uri = neo4j_uri or settings.neo4j_uri
+        self.neo4j_user = neo4j_user or settings.neo4j_user
+        self.neo4j_password = neo4j_password or settings.neo4j_password
         
         if not self.neo4j_password:
             raise ValueError("NEO4J_PASSWORD environment variable not set")
         
         # LLM configuration
-        self.llm_base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1")
-        self.llm_api_key = os.getenv("LLM_API_KEY")
-        self.llm_choice = os.getenv("LLM_CHOICE", "gpt-4.1-mini")
+        self.llm_base_url = settings.llm_base_url
+        self.llm_api_key = settings.llm_api_key
+        self.llm_choice = settings.llm_choice
         
         if not self.llm_api_key:
             raise ValueError("LLM_API_KEY environment variable not set")
         
         # Embedding configuration
-        self.embedding_base_url = os.getenv("EMBEDDING_BASE_URL", "https://api.openai.com/v1")
-        self.embedding_api_key = os.getenv("EMBEDDING_API_KEY")
-        self.embedding_model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
-        self.embedding_dimensions = int(os.getenv("VECTOR_DIMENSION", "1536"))
-        
+        self.embedding_base_url = settings.embedding_base_url
+        self.embedding_api_key = settings.embedding_api_key or settings.llm_api_key
+        self.embedding_model = settings.embedding_model
+        self.embedding_dimensions = settings.vector_dimension
+
         if not self.embedding_api_key:
             raise ValueError("EMBEDDING_API_KEY environment variable not set")
         

--- a/src/fastapi_app/tools.py
+++ b/src/fastapi_app/tools.py
@@ -1,16 +1,11 @@
-"""
-Tools for the Pydantic AI agent.
-"""
+"""Tools for the Pydantic AI agent."""
 
-import os
 import logging
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 import asyncio
 
 from pydantic import BaseModel, Field
-from dotenv import load_dotenv
-
 from .db_utils import (
     vector_search,
     hybrid_search,
@@ -25,9 +20,6 @@ from .graph_utils import (
 )
 from .models import ChunkResult, GraphSearchResult, DocumentMetadata
 from .providers import get_embedding_client, get_embedding_model
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -1,18 +1,10 @@
-"""
-Semantic chunking implementation for intelligent document splitting.
-"""
+"""Semantic chunking implementation for intelligent document splitting."""
 
-import os
 import re
 import logging
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass
 import asyncio
-
-from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/embedder.py
+++ b/src/ingestion/embedder.py
@@ -1,8 +1,5 @@
-"""
-Document embedding generation for vector search.
-"""
+"""Document embedding generation for vector search."""
 
-import os
 import asyncio
 import logging
 from typing import List, Dict, Any, Optional, Tuple
@@ -10,15 +7,11 @@ from datetime import datetime
 import json
 
 from openai import RateLimitError, APIError
-from dotenv import load_dotenv
 
 from .chunker import DocumentChunk
 
 # Import flexible providers
 from fastapi_app.providers import get_embedding_client, get_embedding_model
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/graph_builder.py
+++ b/src/ingestion/graph_builder.py
@@ -1,8 +1,5 @@
-"""
-Knowledge graph builder for extracting entities and relationships.
-"""
+"""Knowledge graph builder for extracting entities and relationships."""
 
-import os
 import logging
 from typing import List, Dict, Any, Optional, Set, Tuple
 from datetime import datetime, timezone
@@ -10,15 +7,11 @@ import asyncio
 import re
 
 from graphiti_core import Graphiti
-from dotenv import load_dotenv
 
 from .chunker import DocumentChunk
 
 # Import graph utilities
 from fastapi_app.graph_utils import GraphitiClient
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/ingest.py
+++ b/src/ingestion/ingest.py
@@ -13,7 +13,6 @@ from datetime import datetime
 import argparse
 
 import asyncpg
-from dotenv import load_dotenv
 
 from .chunker import ChunkingConfig, create_chunker, DocumentChunk
 from .embedder import create_embedder
@@ -23,9 +22,6 @@ from .graph_builder import create_graph_builder
 from fastapi_app.db_utils import initialize_database, close_database, db_pool
 from fastapi_app.graph_utils import initialize_graph, close_graph
 from fastapi_app.models import IngestionConfig, IngestionResult
-
-# Load environment variables
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,35 @@
+from pydantic import BaseSettings, Field
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    llm_api_key: str = Field(..., env="LLM_API_KEY")
+    database_url: str = Field(..., env="DATABASE_URL")
+
+    llm_choice: str = Field("gpt-4-turbo-preview", env="LLM_CHOICE")
+    llm_base_url: str = Field("https://api.openai.com/v1", env="LLM_BASE_URL")
+    llm_provider: str = Field("openai", env="LLM_PROVIDER")
+
+    embedding_api_key: str | None = Field(None, env="EMBEDDING_API_KEY")
+    embedding_base_url: str = Field("https://api.openai.com/v1", env="EMBEDDING_BASE_URL")
+    embedding_model: str = Field("text-embedding-3-small", env="EMBEDDING_MODEL")
+    embedding_provider: str = Field("openai", env="EMBEDDING_PROVIDER")
+
+    ingestion_llm_choice: str | None = Field(None, env="INGESTION_LLM_CHOICE")
+
+    app_env: str = Field("development", env="APP_ENV")
+    app_host: str = Field("0.0.0.0", env="APP_HOST")
+    app_port: int = Field(8000, env="APP_PORT")
+    log_level: str = Field("INFO", env="LOG_LEVEL")
+
+    neo4j_uri: str = Field("bolt://localhost:7687", env="NEO4J_URI")
+    neo4j_user: str = Field("neo4j", env="NEO4J_USER")
+    neo4j_password: str | None = Field(None, env="NEO4J_PASSWORD")
+
+    vector_dimension: int = Field(1536, env="VECTOR_DIMENSION")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add reusable `Settings` based on `pydantic.BaseSettings`
- refactor FastAPI and ingestion modules to use shared settings instead of `load_dotenv`
- mirror settings refactor for agentic knowledge graph modules

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ingestion.py and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68994f8f8560832ab5628f3f5df5ad7f

## Summary by Sourcery

Centralize application configuration by introducing Pydantic-based Settings classes and refactoring all modules to use a shared settings instance instead of manual dotenv loading and os.getenv calls.

New Features:
- Add src/settings.py and agentic-rag-knowledge-graph/settings.py using Pydantic BaseSettings to define and validate all environment variables.

Enhancements:
- Replace load_dotenv and direct os.getenv usage across FastAPI API endpoints, providers, graph utilities, database utilities, agent modules, and ingestion pipelines to pull from the shared Settings instance.
- Fail fast on missing required configuration (LLM_API_KEY, DATABASE_URL) and mirror the configuration refactor in the agentic-knowledge-graph subproject.