### PR TITLE
📝 Add docstrings to `codex/integrate-rate-limiting-library`

### DIFF
--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -187,7 +187,7 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
         exc: The RateLimitExceeded exception instance (not inspected by this handler).
     
     Returns:
-        fastapi.responses.JSONResponse with status code 429 and the JSON body described above.
+        JSONResponse with status code 429 and the JSON body described above.
     """
     logger.warning(f"Rate limit exceeded: {rate_limit_key(request)}")
     return JSONResponse(


### PR DESCRIPTION
Docstrings generation was requested by @cbwinslow.

* https://github.com/cbwinslow/hetzner_app/pull/10#issuecomment-3173138178

The following files were modified:

* `src/fastapi_app/api.py`
* `src/fastapi_app/tests/test_api.py`

## Summary by Sourcery

Add comprehensive docstrings to API endpoint functions, helper routines, and pytest fixtures to improve code self-documentation and clarity.

Documentation:
- Add detailed docstrings to rate_limit_key, rate_limit_handler, get_or_create_session, chat, chat_stream, and generate_stream describing their behavior, parameters, returns, and side effects
- Expand pytest fixture docstrings in test_api.py to explain patched functions, return values, and yielded values for database, graph, agent execution, tools, and streaming events