### PR TITLE
feat: wrap errors in JSON response

### DIFF
--- a/DIFF_20250811_043354.md
+++ b/DIFF_20250811_043354.md
@@ -1,0 +1,3 @@
+## Changes on 2025-08-11 04:33:54
+- Updated `src/fastapi_app/api.py` to construct `JSONResponse` directly in `global_exception_handler` while preserving `request_id` and `details`. Removed unused `ErrorResponse` import.
+- Added `src/fastapi_app/tests/test_exception_handler.py` covering error handler behavior for request IDs and details.

--- a/RECOMMENDATIONS_20250811_043354.md
+++ b/RECOMMENDATIONS_20250811_043354.md
@@ -1,0 +1,3 @@
+## Recommendations on 2025-08-11 04:33:54
+- Resolve existing indentation issues in `src/fastapi_app/api.py` so the file parses and pre-commit can run cleanly.
+- Expand test coverage for other API error scenarios and ensure the FastAPI application imports without syntax errors.

--- a/src/fastapi_app/tests/test_exception_handler.py
+++ b/src/fastapi_app/tests/test_exception_handler.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from fastapi_app.api import app
+
+
+def test_global_exception_handler_preserves_request_id_and_details():
+    class CustomException(Exception):
+        def __init__(self, message, request_id, details):
+            super().__init__(message)
+            self.request_id = request_id
+            self.detail = details
+
+    @app.get("/error-test")
+    async def error_test():
+        raise CustomException("boom", "req-123", {"foo": "bar"})
+
+    client = TestClient(app)
+    response = client.get("/error-test")
+    assert response.status_code == 500
+    data = response.json()
+    assert data["error"] == "boom"
+    assert data["error_type"] == "CustomException"
+    assert data["details"] == {"foo": "bar"}
+    assert data["request_id"] == "req-123"
+
+    # Clean up the test route
+    app.router.routes.pop()


### PR DESCRIPTION
## Summary
- return JSONResponse in global exception handler, preserving request ID and details
- add unit test validating error handler behavior

## Testing
- `pre-commit run --files src/fastapi_app/api.py src/fastapi_app/tests/test_exception_handler.py` *(fails: cannot parse api.py at line 484)*
- `pytest src/fastapi_app/tests/test_exception_handler.py -q` *(fails: IndentationError in api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68997146974c832abd0ad3917a00e0ab