### PR TITLE
feat: handle stream errors gracefully

### DIFF
--- a/DIFF_20250811_043437.md
+++ b/DIFF_20250811_043437.md
@@ -1,0 +1,4 @@
+- Added missing FastAPI imports and response/security helpers in `src/fastapi_app/api.py`.
+- Initialized logger, rate limiter, and security middleware.
+- Defined `/chat` and `/chat/stream` endpoints with proper function signatures.
+- Wrapped the body of `generate_stream` in `try/except/finally` to emit SSE error events, close runs, and send terminating `end` events.

--- a/RECOMMENDATIONS_20250811_043437.md
+++ b/RECOMMENDATIONS_20250811_043437.md
@@ -1,0 +1,3 @@
+- Refactor `api.py` to remove unreachable sections and reintroduce missing endpoint definitions.
+- Add tests verifying SSE error and end events in `generate_stream`.
+- Validate test modules for syntax errors so automated checks run cleanly.

--- a/src/fastapi_app/api.py
+++ b/src/fastapi_app/api.py
@@ -9,8 +9,11 @@ from datetime import datetime
 import uuid
 
 
+from fastapi import FastAPI, HTTPException, Request, Depends, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import uvicorn
 
 
@@ -86,10 +89,9 @@ langfuse = Langfuse()
 
 # --- End OpenTelemetry ---
 
-
-
-
-
+logger = logging.getLogger(__name__)
+limiter = Limiter(key_func=get_remote_address)
+security = HTTPBearer()
 
 
 async def auth_dependency(
@@ -481,7 +483,8 @@ async def health_check():
 
 
 @app.post("/chat", response_model=ChatResponse)
-
+async def chat(chat_request: ChatRequest):
+    """Chat endpoint."""
     try:
         # Get or create session
         session_id = await get_or_create_session(chat_request)
@@ -506,13 +509,14 @@ async def health_check():
 
 
 @app.post("/chat/stream")
-
+async def chat_stream(chat_request: ChatRequest):
+    """Streaming chat endpoint using Server-Sent Events."""
     try:
         # Get or create session
         session_id = await get_or_create_session(chat_request)
 
         async def generate_stream() -> AsyncGenerator[str, None]:
-
+            run = None
             try:
                 yield f"data: {json.dumps({'type': 'session', 'session_id': session_id})}\n\n"
 
@@ -530,7 +534,9 @@ async def health_check():
                     context_str = "\n".join(
                         [f"{msg['role']}: {msg['content']}" for msg in context[-6:]]
                     )
-
+                    full_prompt = (
+                        f"Previous conversation:\n{context_str}\n\nCurrent question: {chat_request.message}"
+                    )
 
                 # Save user message immediately
                 await add_message(
@@ -543,7 +549,10 @@ async def health_check():
                 full_response = ""
 
                 # Stream using agent.iter() pattern
-
+                async with rag_agent.iter(full_prompt, deps=deps) as run:
+                    async for node in run:
+                        if rag_agent.is_model_request_node(node):
+                            async with node.stream(run.ctx) as request_stream:
                                 async for event in request_stream:
                                     from pydantic_ai.messages import (
                                         PartStartEvent,
@@ -596,7 +605,12 @@ async def health_check():
 
             except Exception as e:
                 logger.error(f"Stream error: {e}")
-
+                error_chunk = {"type": "error", "content": str(e)}
+                yield f"data: {json.dumps(error_chunk)}\n\n"
+            finally:
+                if run is not None:
+                    try:
+                        await run.close()
                     except Exception as close_err:
                         logger.error(f"Error closing run: {close_err}")
                 yield f"data: {json.dumps({'type': 'end'})}\n\n"


### PR DESCRIPTION
## Summary
- add missing FastAPI imports and initialize logger, rate limiter, and auth security
- implement `/chat` and `/chat/stream` endpoints
- wrap streaming generator in try/except/finally to emit SSE error and end events while closing runs

## Testing
- `pytest src/fastapi_app/tests/test_api.py::test_chat_stream_error -q` *(fails: SyntaxError in test file)*

------
https://chatgpt.com/codex/tasks/task_e_68997150f3e8832a9379ab8a03072d95