### PR TITLE
Centralize environment configuration with pydantic settings

### DIFF
--- a/DIFF_20250811_043812.md
+++ b/DIFF_20250811_043812.md
@@ -1,0 +1,8 @@
+## Changes made on 2025-08-11 04:38:12
+- Introduced `Settings` powered by `pydantic-settings` with centralized environment validation, including `API_AUTH_TOKEN` and parsed `ALLOWED_ORIGINS`.
+- Removed per-module `os.getenv` usage in favor of shared `settings` instance.
+- Updated `logging_config` to read log level from `settings`.
+- Refactored `db_utils` authentication helpers to use `settings.api_auth_token`.
+- Rewrote `providers` module to construct clients and model info from `settings` values.
+- Enhanced `api` module with explicit FastAPI imports, configuration from `settings`, and a `rate_limit_key` helper.
+- Added missing `get_logger` import in `graph_utils`.

--- a/RECOMMENDATIONS_20250811_043812.md
+++ b/RECOMMENDATIONS_20250811_043812.md
@@ -1,0 +1,4 @@
+## Recommendations logged on 2025-08-11 04:38:12
+- Replace deprecated `Field` `env` arguments across remaining modules to avoid future warnings.
+- Add error handling or validation when `allowed_origins` is empty to prevent unintended CORS exposure.
+- Repair or complete the test suite (e.g., `test_cors.py`) to ensure meaningful automated verification.

--- a/src/fastapi_app/db_utils.py
+++ b/src/fastapi_app/db_utils.py
@@ -10,17 +10,16 @@ from uuid import UUID
 import asyncpg
 from asyncpg.pool import Pool
 
+from logging_config import get_logger
+from settings import settings
 
 logger = get_logger(__name__)
+API_AUTH_TOKEN = settings.api_auth_token
 
 
 async def verify_auth_token(token: str) -> bool:
-    """Verify bearer token using environment variable."""
-    expected = os.getenv("API_AUTH_TOKEN")
-    if not expected:
-        logger.warning("API_AUTH_TOKEN not set")
-        return False
-    return token == expected
+    """Verify bearer token against configured token."""
+    return token == API_AUTH_TOKEN
 
 
 class DatabasePool:
@@ -78,9 +77,6 @@ async def initialize_database():
 
 
 # Authentication utilities
-API_AUTH_TOKEN = os.getenv("API_AUTH_TOKEN")
-if not API_AUTH_TOKEN:
-    raise ValueError("API_AUTH_TOKEN environment variable must be set for authentication")
 
 
 async def verify_token(token: str) -> bool:

--- a/src/fastapi_app/graph_utils.py
+++ b/src/fastapi_app/graph_utils.py
@@ -15,6 +15,7 @@ from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerCli
 
 
 
+from logging_config import get_logger
 from settings import settings
 
 logger = get_logger(__name__)

--- a/src/fastapi_app/providers.py
+++ b/src/fastapi_app/providers.py
@@ -1,95 +1,68 @@
 """Flexible provider configuration for LLM and embedding models."""
 
-
 from typing import Optional
+
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.openai import OpenAIModel
 import openai
 
+from settings import settings
 
 
 def get_llm_model(model_choice: Optional[str] = None) -> OpenAIModel:
-    """
-    Get LLM model configuration based on environment variables.
-
-    Args:
-        model_choice: Optional override for model choice
-
-    Returns:
-        Configured OpenAI-compatible model
-    """
-
-    provider = OpenAIProvider(base_url=base_url, api_key=api_key)
+    """Get LLM model configuration based on settings."""
+    llm_choice = model_choice or settings.llm_choice
+    provider = OpenAIProvider(base_url=settings.llm_base_url, api_key=settings.llm_api_key)
     return OpenAIModel(llm_choice, provider=provider)
 
 
 def get_embedding_client() -> openai.AsyncOpenAI:
-    """
-    Get embedding client configuration based on environment variables.
-
-    Returns:
-        Configured OpenAI-compatible client for embeddings
-    """
-
+    """Get embedding client based on settings."""
+    return openai.AsyncOpenAI(
+        api_key=settings.embedding_api_key or settings.llm_api_key,
+        base_url=settings.embedding_base_url,
+    )
 
 
 def get_embedding_model() -> str:
-    """
-    Get embedding model name from environment.
-
-    Returns:
-        Embedding model name
-    """
-
+    """Get embedding model name from settings."""
+    return settings.embedding_model
 
 
 def get_ingestion_model() -> OpenAIModel:
-    """
-    Get ingestion-specific LLM model (can be faster/cheaper than main model).
-
-    Returns:
-        Configured model for ingestion tasks
-    """
-
-    # If no specific ingestion model, use the main model
+    """Get ingestion-specific LLM model."""
+    ingestion_choice = settings.ingestion_llm_choice
     if not ingestion_choice:
         return get_llm_model()
-
     return get_llm_model(model_choice=ingestion_choice)
 
 
 # Provider information functions
+
 def get_llm_provider() -> str:
     """Get the LLM provider name."""
-
+    return settings.llm_provider
 
 
 def get_embedding_provider() -> str:
     """Get the embedding provider name."""
-
+    return settings.embedding_provider
 
 
 def validate_configuration() -> bool:
-    """
-    Validate that required environment variables are set.
+    """Validate that required settings are present."""
+    try:
+        _ = settings
+        return True
+    except Exception:
+        return False
 
-    Returns:
-
-    """
-
-
-
-
-    return True
 
 def get_model_info() -> dict:
-    """
-    Get information about current model configuration.
-
-    Returns:
-        Dictionary with model configuration info
-    """
+    """Get information about current model configuration."""
     return {
         "llm_provider": get_llm_provider(),
-
+        "llm_model": settings.llm_choice,
+        "embedding_provider": get_embedding_provider(),
+        "embedding_model": settings.embedding_model,
     }

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,8 +1,9 @@
 import logging
-import os
 from logging.config import dictConfig
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+from settings import settings
+
+LOG_LEVEL = settings.log_level.upper()
 
 LOGGING_CONFIG = {
     "version": 1,

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,35 +1,43 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    llm_api_key: str = Field(..., env="LLM_API_KEY")
-    database_url: str = Field(..., env="DATABASE_URL")
+    llm_api_key: str
+    database_url: str
 
-    llm_choice: str = Field("gpt-4-turbo-preview", env="LLM_CHOICE")
-    llm_base_url: str = Field("https://api.openai.com/v1", env="LLM_BASE_URL")
-    llm_provider: str = Field("openai", env="LLM_PROVIDER")
+    llm_choice: str = "gpt-4-turbo-preview"
+    llm_base_url: str = "https://api.openai.com/v1"
+    llm_provider: str = "openai"
 
-    embedding_api_key: str | None = Field(None, env="EMBEDDING_API_KEY")
-    embedding_base_url: str = Field("https://api.openai.com/v1", env="EMBEDDING_BASE_URL")
-    embedding_model: str = Field("text-embedding-3-small", env="EMBEDDING_MODEL")
-    embedding_provider: str = Field("openai", env="EMBEDDING_PROVIDER")
+    embedding_api_key: str | None = None
+    embedding_base_url: str = "https://api.openai.com/v1"
+    embedding_model: str = "text-embedding-3-small"
+    embedding_provider: str = "openai"
 
-    ingestion_llm_choice: str | None = Field(None, env="INGESTION_LLM_CHOICE")
+    ingestion_llm_choice: str | None = None
 
-    app_env: str = Field("development", env="APP_ENV")
-    app_host: str = Field("0.0.0.0", env="APP_HOST")
-    app_port: int = Field(8000, env="APP_PORT")
-    log_level: str = Field("INFO", env="LOG_LEVEL")
+    app_env: str = "development"
+    app_host: str = "0.0.0.0"
+    app_port: int = 8000
+    log_level: str = "INFO"
+    api_auth_token: str
+    allowed_origins: list[str] = Field(default_factory=list)
 
-    neo4j_uri: str = Field("bolt://localhost:7687", env="NEO4J_URI")
-    neo4j_user: str = Field("neo4j", env="NEO4J_USER")
-    neo4j_password: str | None = Field(None, env="NEO4J_PASSWORD")
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str | None = None
 
-    vector_dimension: int = Field(1536, env="VECTOR_DIMENSION")
+    vector_dimension: int = 1536
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def split_origins(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return [o.strip() for o in v.split(",") if o.strip()]
+        return v
+
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- Consolidate environment handling into a single `Settings` class using `pydantic-settings`
- Replace scattered `os.getenv` calls with a shared settings instance across modules
- Configure logging and service providers from validated settings

## Testing
- `LLM_API_KEY=dummy DATABASE_URL=postgresql://user:pass@localhost:5432/db API_AUTH_TOKEN=test NEO4J_PASSWORD=dummy pytest` *(fails: IndentationError in test_cors.py)*


------
https://chatgpt.com/codex/tasks/task_e_6899714e9778832ab3c8f3d5683d80d6

## Summary by Sourcery

Centralize environment configuration using a Pydantic Settings class and refactor modules to consume configuration from the unified settings instance

New Features:
- Add rate_limit_key helper for FastAPI rate limiting using client address

Enhancements:
- Introduce a Pydantic Settings class to consolidate all environment variables and defaults
- Replace scattered os.getenv calls in providers, database, and logging modules with the shared settings instance
- Refactor provider functions to construct LLM and embedding clients and model info from validated settings
- Update logging configuration to derive log level from the Settings instance
- Refactor database utilities to use settings.api_auth_token for authentication