### PR TITLE
Add Caddy Cloudflare TLS setup with helper scripts and tests

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,10 @@
+{
+    email {$LETSENCRYPT_EMAIL}
+}
+
+{$DOMAIN} {
+    tls {
+        dns cloudflare {$CLOUDFLARE_API_TOKEN}
+    }
+    reverse_proxy 127.0.0.1:8080
+}

--- a/DIFF_20250812_123129.md
+++ b/DIFF_20250812_123129.md
@@ -1,0 +1,7 @@
+## Changes on 2025-08-12 12:31:29 UTC
+- Added Caddyfile for automatic TLS with Cloudflare DNS challenge.
+- Created scripts/22_caddy_cloudflare_setup.sh to install and configure Caddy with Cloudflare plugin.
+- Added install_all.sh wrapper for one-click deployment including Caddy setup.
+- Updated tests/test_scripts.py to include new helper scripts.
+- Added tests/test_caddyfile.py to verify Caddyfile uses Cloudflare DNS.
+- Updated README-DEPLOYMENT.md with Caddy TLS instructions and one-click installer usage.

--- a/README-DEPLOYMENT.md
+++ b/README-DEPLOYMENT.md
@@ -40,6 +40,22 @@ cd /opt/supabase-super-stack
 sudo ./start-platform.sh
 ```
 
+### Optional: Caddy with Cloudflare TLS
+To automatically provision TLS certificates through Cloudflare, configure Caddy:
+
+```bash
+export DOMAIN=opendiscourse.net
+export LETSENCRYPT_EMAIL=you@example.com
+export CLOUDFLARE_API_TOKEN=your_cloudflare_api_token
+sudo ./scripts/22_caddy_cloudflare_setup.sh
+```
+
+For a one-click installation that runs the Caddy setup and full deployment:
+
+```bash
+sudo ./install_all.sh
+```
+
 ### 4. Monitor AI Agents
 ```bash
 sudo ./monitor-agents.sh

--- a/RECOMMENDATIONS_20250812_123129.md
+++ b/RECOMMENDATIONS_20250812_123129.md
@@ -1,0 +1,4 @@
+## Recommendations on 2025-08-12 12:31:29 UTC
+- Consider integrating Caddy into deploy.sh to replace Traefik if desired.
+- Add unit tests for the install_all.sh workflow using a temporary environment.
+- Automate environment variable management for Cloudflare tokens via secret store.

--- a/install_all.sh
+++ b/install_all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Wrapper script to configure Caddy with Cloudflare and run deploy
+./scripts/22_caddy_cloudflare_setup.sh
+./deploy.sh "$@"

--- a/scripts/22_caddy_cloudflare_setup.sh
+++ b/scripts/22_caddy_cloudflare_setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install dependencies
+if ! command -v envsubst >/dev/null 2>&1; then
+  apt-get update -y
+  apt-get install -y gettext-base
+fi
+
+# Check required environment variables
+: "${DOMAIN:?DOMAIN not set}"
+: "${LETSENCRYPT_EMAIL:?LETSENCRYPT_EMAIL not set}"
+: "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN not set}"
+
+# Download Caddy with Cloudflare DNS plugin
+if ! command -v caddy >/dev/null 2>&1; then
+  echo "Installing Caddy with Cloudflare DNS plugin..."
+  curl -fsSL "https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com/caddy-dns/cloudflare" \
+    | tar xzf - -C /usr/local/bin caddy
+fi
+
+install -d /etc/caddy
+
+envsubst < Caddyfile > /etc/caddy/Caddyfile
+
+cat <<'SERVICE' > /etc/systemd/system/caddy.service
+[Unit]
+Description=Caddy web server
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/caddy run --environ --config /etc/caddy/Caddyfile
+ExecReload=/usr/local/bin/caddy reload --config /etc/caddy/Caddyfile
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable caddy
+systemctl restart caddy
+
+echo "Caddy with Cloudflare DNS configured and running."

--- a/tests/test_caddyfile.py
+++ b/tests/test_caddyfile.py
@@ -1,0 +1,5 @@
+import pathlib
+
+def test_caddyfile_uses_cloudflare_dns():
+    contents = pathlib.Path('Caddyfile').read_text()
+    assert 'dns cloudflare' in contents

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -10,6 +10,8 @@ SCRIPTS = [
     pathlib.Path("post-deploy-setup.sh"),
     pathlib.Path("push_to_remotes.sh"),
     pathlib.Path("tests/test_deploy.sh"),
+    pathlib.Path("scripts/22_caddy_cloudflare_setup.sh"),
+    pathlib.Path("install_all.sh"),
 ]
 
 @pytest.mark.parametrize("script", SCRIPTS, ids=[str(s) for s in SCRIPTS])


### PR DESCRIPTION
## Summary
- add Caddyfile configured for Cloudflare DNS challenge
- provide script to install Caddy with Cloudflare support and wrapper for one-click deployment
- document new Caddy workflow in deployment README and ensure tests cover scripts

## Testing
- `pytest tests/test_scripts.py tests/test_caddyfile.py`
- `pytest tests/test_shellcheck.py`

------
https://chatgpt.com/codex/tasks/task_e_689b334533fc832ab5f5e600930582b3

## Summary by Sourcery

Provide automated TLS provisioning with Caddy via Cloudflare DNS by adding a Caddyfile, installation and deployment helper scripts, updating documentation, and covering the new workflow with tests.

New Features:
- Add Caddyfile configured for Cloudflare DNS challenge
- Introduce scripts/22_caddy_cloudflare_setup.sh to install and configure Caddy with Cloudflare DNS plugin
- Add install_all.sh wrapper for one-click deployment including Caddy setup

Documentation:
- Document Caddy Cloudflare TLS workflow and one-click installer usage in README-DEPLOYMENT.md

Tests:
- Extend script presence tests to include new Caddy setup and install_all scripts
- Add test_caddyfile.py to verify Caddyfile uses Cloudflare DNS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional automatic TLS via Caddy using Cloudflare DNS challenge.
  * One-click installer to set up TLS and complete deployment in a single step.

* **Documentation**
  * Deployment guide updated with instructions for configuring Caddy TLS, required environment variables (domain, email, Cloudflare token), and one-click install usage.

* **Tests**
  * Added tests to verify Caddy configuration uses Cloudflare DNS.
  * Extended script checks to ensure new installer and setup scripts use strict bash mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->