### PR TITLE
Add GitHub Action for Docker Compose deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy Stack
+
+on:
+  push:
+    branches: [work]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Pre-Deployment Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit pytest
+          if [ -f src/fastapi_app/requirements.txt ]; then pip install -r src/fastapi_app/requirements.txt; fi
+          if [ -f agentic-rag-knowledge-graph/requirements.txt ]; then pip install -r agentic-rag-knowledge-graph/requirements.txt; fi
+      - name: Shell syntax check
+        run: bash -n deploy.sh
+      - name: Run pre-commit
+        run: pre-commit run --files $(git ls-files)
+      - name: Run tests
+        run: pytest
+
+  deploy:
+    name: Deploy Stack
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.DEPLOY_PATH }}
+            git pull
+            sudo bash deploy.sh
+            APP_ROOT=$(sudo bash -lc 'source config.sh; echo $APP_ROOT')
+            sudo docker-compose -f "$APP_ROOT/docker-compose.yml" up -d
+
+  post-deploy:
+    name: Post-Deployment Checks
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify services
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.DEPLOY_PATH }}
+            APP_ROOT=$(sudo bash -lc 'source config.sh; echo $APP_ROOT')
+            DOMAIN=$(sudo bash -lc 'source config.sh; echo $DOMAIN')
+            sudo docker-compose -f "$APP_ROOT/docker-compose.yml" ps
+            curl -f "https://${DOMAIN}" || exit 1

--- a/DIFF_20250817_004915.md
+++ b/DIFF_20250817_004915.md
@@ -1,0 +1,3 @@
+## Changes on 2025-08-17
+- Added GitHub Action workflow at `.github/workflows/deploy.yml` to run tests, deploy via SSH, and perform post-deployment health checks using Docker Compose.
+- Updated `README.md` with instructions for the new GitHub Action deployment workflow.

--- a/DIFF_20250817_122503.md
+++ b/DIFF_20250817_122503.md
@@ -1,0 +1,3 @@
+- Update post-deploy step in `.github/workflows/deploy.yml` to verify `https://opendiscourse.net` using the configured domain.
+- Replace placeholder URLs in `README.md` with `opendiscourse.net` and mention domain verification in the CI/CD section.
+

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ This is a one-time setup to initialize the database and get your unique Supabase
 
 Your application is now fully deployed and operational!
 
+## CI/CD via GitHub Actions
+
+Automated deployments are provided by the `deploy.yml` workflow. The pipeline runs linting and tests, deploys the stack to a remote host over SSH using `deploy.sh` and Docker Compose, and verifies https://opendiscourse.net after the deployment. Configure `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_KEY`, and `DEPLOY_PATH` secrets to enable this workflow.
+
 ---
 
 ## TUI Service Menu
@@ -124,12 +128,12 @@ Use the arrow keys to navigate and press Enter to run the selected action.
 
 ## Usage Guide
 
--   **Main Application:** `https://your-domain.com`
--   **API Documentation:** `https://api.your-domain.com/docs`
--   **AI Prototyping Lab (Flowise):** `https://flowise.your-domain.com`
--   **Workflow Automation (n8n):** `https://n8n.your-domain.com`
--   **LLM Observability (Langfuse):** `https://langfuse.your-domain.com`
--   **Observability (Jaeger):** `https://jaeger.your-domain.com`
--   **Traefik Dashboard:** `https://traefik.your-domain.com`
+-   **Main Application:** `https://opendiscourse.net`
+-   **API Documentation:** `https://api.opendiscourse.net/docs`
+-   **AI Prototyping Lab (Flowise):** `https://flowise.opendiscourse.net`
+-   **Workflow Automation (n8n):** `https://n8n.opendiscourse.net`
+-   **LLM Observability (Langfuse):** `https://langfuse.opendiscourse.net`
+-   **Observability (Jaeger):** `https://jaeger.opendiscourse.net`
+-   **Traefik Dashboard:** `https://traefik.opendiscourse.net`
 
 

--- a/RECOMMENDATIONS_20250817_004915.md
+++ b/RECOMMENDATIONS_20250817_004915.md
@@ -1,0 +1,3 @@
+## Recommendations on 2025-08-17
+- Consider adding automated rollback in the GitHub Action to revert the deployment if post-deployment health checks fail.
+- Expand test coverage and include integration tests to increase confidence before deployments.

--- a/RECOMMENDATIONS_20250817_122503.md
+++ b/RECOMMENDATIONS_20250817_122503.md
@@ -1,0 +1,3 @@
+- Allow the GitHub Actions workflow to parameterize the domain for easier reuse across environments.
+- Extend post-deployment checks with service-specific health endpoints (e.g., /health for API) to catch issues earlier.
+


### PR DESCRIPTION
## Summary
- Add workflow for pre-commit, tests, and Docker Compose deployment over SSH
- Document the deployment workflow in README
- Verify https://opendiscourse.net after deployment and document domain-specific URLs

## Testing
- `pre-commit run --files .github/workflows/deploy.yml README.md DIFF_20250817_122503.md RECOMMENDATIONS_20250817_122503.md`
- `pytest` *(fails: SyntaxError in logging_config and missing module 'pika')*

------
https://chatgpt.com/codex/tasks/task_e_68a125dccdd0832a87c403049874658b